### PR TITLE
[REF] Reformat rapidtide parser and usage documentation

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -4,17 +4,6 @@ For more information about how the rapidtide library can be used, please
 see the API page. Common rapidtide workflows can also be called from the
 command line.
 
-Run rapidtide
--------------
-This is the full rapidtide workflow. The learn more about this workflow,
-check out the workflow documentation:
-:py:func:`rapidtide.workflows.rapidtide_workflow`.
-
-.. argparse::
-   :ref: rapidtide.workflows.rapidtide_parser._get_parser
-   :prog: rapidtide
-   :func: _get_parser
-
 Running from the command line
 -----------------------------
 rapidtide
@@ -77,7 +66,7 @@ BIDS Outputs:
    "XXX_desc-corrfitwindow_info", ".nii.gz", "Values used for correlation peak fitting", "Always"
    "XXX_desc-runoptions_info", ".json", "A detailed dump of all internal variables in the program.  Useful for debugging and data provenance", "Always"
    "XXX_desc-lfofilterCleaned_bold", ".nii.gz, .json", "Filtered BOLD dataset after removing moving regressor", "If GLM filtering is enabled (default)"
-   "XXX_desc-lfofilterRemoved_bold", ".nii.gz, .json", "Scaled, voxelwise delayed moving regressor that has been removed from the dataset", "If GLM filtering is enabled (default) and `--nolimitoutput` is selected"
+   "XXX_desc-lfofilterRemoved_bold", ".nii.gz, .json", "Scaled, voxelwise delayed moving regressor that has been removed from the dataset", "If GLM filtering is enabled (default) and ``--nolimitoutput`` is selected"
    "XXX_desc-lfofilterCoeff_map", ".nii.gz", "Magnitude of the delayed sLFO regressor from GLM filter", "If GLM filtering is enabled (default)"
    "XXX_desc-lfofilterMean_map", ".nii.gz", "Mean value over time, from GLM fit", "If GLM filtering is enabled (default)"
    "XXX_desc-lfofilterNorm_map", ".nii.gz", "GLM filter coefficient, divided by the voxel mean over time", "If GLM filtering is enabled (default)"
@@ -90,12 +79,12 @@ BIDS Outputs:
    "XXX_desc-corrout_info", ".nii.gz", "Full similarity function over the search range", "Always"
    "XXX_desc-gaussout_info", ".nii.gz", "Gaussian fit to similarity function peak over the search range", "Always"
    "XXX_desc-autocorr_timeseries", ".tsv, .json", "Autocorrelation of the probe regressor for each pass", "Always"
-   "XXX_desc-corrdistdata_info", ".tsv, .json", "Null correlations from the significance estimation for each pass", "Present if --numnull > 0"
-   "XXX_desc-nullsimfunc_hist", ".tsv, .json", "Histogram of the distribution of null correlation values for each pass", "Present if --numnull > 0"
-   "XXX_desc-plt0p050_mask", ".nii.gz", "Voxels where the maxcorr value exceeds the p < 0.05 significance level", "Present if --numnull > 0"
-   "XXX_desc-plt0p010_mask", ".nii.gz", "Voxels where the maxcorr value exceeds the p < 0.01 significance level", "Present if --numnull > 0"
-   "XXX_desc-plt0p005_mask", ".nii.gz", "Voxels where the maxcorr value exceeds the p < 0.005 significance level", "Present if --numnull > 0"
-   "XXX_desc-plt0p001_mask", ".nii.gz", "Voxels where the maxcorr value exceeds the p < 0.001 significance level", "Present if --numnull > 0"
+   "XXX_desc-corrdistdata_info", ".tsv, .json", "Null correlations from the significance estimation for each pass", "Present if ``--numnull`` > 0"
+   "XXX_desc-nullsimfunc_hist", ".tsv, .json", "Histogram of the distribution of null correlation values for each pass", "Present if ``--numnull`` > 0"
+   "XXX_desc-plt0p050_mask", ".nii.gz", "Voxels where the maxcorr value exceeds the p < 0.05 significance level", "Present if ``--numnull`` > 0"
+   "XXX_desc-plt0p010_mask", ".nii.gz", "Voxels where the maxcorr value exceeds the p < 0.01 significance level", "Present if ``--numnull`` > 0"
+   "XXX_desc-plt0p005_mask", ".nii.gz", "Voxels where the maxcorr value exceeds the p < 0.005 significance level", "Present if ``--numnull`` > 0"
+   "XXX_desc-plt0p001_mask", ".nii.gz", "Voxels where the maxcorr value exceeds the p < 0.001 significance level", "Present if ``--numnull`` > 0"
    "XXX_desc-globallag_hist", ".tsv, .json", "Histogram of peak correlation times between probe and all voxels, over all time lags, for each pass", "Always"
    "XXX_desc-initialmovingregressor_timeseries", ".tsv, .json", "The raw and filtered initial probe regressor, at the original sampling resolution", "Always"
    "XXX_desc-movingregressor_timeseries", ".tsv, .json", "The probe regressor used in each pass, at the time resolution of the data", "Always"
@@ -107,6 +96,13 @@ BIDS Outputs:
 Usage:
 """"""
 
+.. argparse::
+   :ref: rapidtide.workflows.rapidtide_parser._get_parser
+   :prog: rapidtide
+   :func: _get_parser
+
+   Debugging options : @skip
+      skip debugging options
 
     ::
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -4,13 +4,19 @@ For more information about how the rapidtide library can be used, please
 see the API page. Common rapidtide workflows can also be called from the
 command line.
 
-Running from the command line
------------------------------
+..
+   Headings are organized in this manner:
+   =====
+   -----
+   ^^^^^
+   """""
+   '''''
+
 rapidtide
-^^^^^^^^^
+---------
 
 Description:
-""""""""""""
+^^^^^^^^^^^^
 
 The central program in this package is rapidtide.  This is the program that calculates a similarity function between a "probe" signal and every voxel of a BOLD fMRI dataset.  It then determines the peak value, time delay, and wi
 dth of the similarity function to determine when and how strongly that probe signal appears in each voxel.
@@ -31,7 +37,7 @@ At its core, rapidtide is simply performing a full crosscorrelation between a "p
 * There are a lot of tuning parameters you can mess with if you feel the need.  I've tried to make intelligent defaults so things will work well out of the box, but you have the ability to set most of the interesting parameters yourself.
 
 Inputs:
-"""""""
+^^^^^^^
 
 At a minimum, rapidtide needs a data file to work on (space by time), which is generally thought to be a BOLD fMRI data file.  This can be Nifti1 or Nifti2 (for fMRI data, in which case it is time by up to 3 spatial dimensions) or a whitespace separated text file (for NIRS data, each column is a time course, each row a separate channel); I can currently read (probably) but not write Cifti files, so if you want to use grayordinate files you need to convert them to nifti2 in workbench, run rapidtide, then convert back. As soon as nibabel finishes their Cifti support (EDIT: and I get around to figuring it out), I'll add that.
 
@@ -40,13 +46,13 @@ The file needs one time dimension and at least one spatial dimension.  Internall
 The file you input here should be the result of any preprocessing you intend to do.  The expectation is that rapidtide will be run as the last preprocessing step before resting state or task based analysis.  So any slice time correction, motion correction, spike removal, etc. should already have been done.  If you use FSL, this means that if you've run preprocessing, you would use the filtered_func_data.nii.gz file as input.  Temporal and spatial filtering are the two (partial) exceptions here.  Generally rapidtide is most useful for looking at low frequency oscillations, so when you run it, you usually use the "--filterband lfo" option or some other to limit the analysis to the detection and removal of low frequency systemic physiological oscillations.  So rapidtide will generally apply it's own temporal filtering on top of whatever you do in preprocessing.  Also, you have the option of doing spatial smoothing in rapidtide to boost the SNR of the analysis; the hemodynamic signals rapidtide looks for are often very smooth, so you rather than smooth your functional data excessively, you can do it within rapidtide so that only the hemodynamic data is smoothed at that level.
 
 Outputs:
-""""""""
+^^^^^^^^
 
 Outputs are space or space by time Nifti or text files, depending on what the input data file was, and some text files containing textual information, histograms, or numbers.  File formats and naming follow BIDS conventions for derivative data for fMRI input data.  Output spatial dimensions and file type match the input dimensions and file type (Nifti1 in, Nifti1 out).  Depending on the file type of map, there can be no time dimension, a time dimension that matches the input file, or something else, such as a time lag dimension for a correlation map.
 
 
 BIDS Outputs:
-"""""""""""""
+^^^^^^^^^^^^^
 
 .. csv-table::
    :header: "Name", "Extension(s)", "Content", "When present"
@@ -94,7 +100,7 @@ BIDS Outputs:
 
 
 Usage:
-""""""
+^^^^^^
 
 .. argparse::
    :ref: rapidtide.workflows.rapidtide_parser._get_parser
@@ -104,8 +110,7 @@ Usage:
    Debugging options : @skip
       skip debugging options
 
-    ::
-
+::
       usage: rapidtide in_file outputname [options]
       Perform a RIPTiDe time delay analysis on a dataset.
 
@@ -402,10 +407,8 @@ Usage:
         --singleproc_fitcorr  Force single proc path for fitcorr.
         --singleproc_glm      Force single proc path for glm.
 
-
-
 Legacy interface:
-"""""""""""""""""
+^^^^^^^^^^^^^^^^^
 For compatibility with old workflows, rapidtide can be called using legacy syntax by using "rapidtide2x_legacy".  Although the underlying code is the same, not all options are settable from the legacy interface.  This interface is deprecated and will be removed in a future version of rapidtide, so please convert existing workflows.
 
 
@@ -643,7 +646,7 @@ These options are somewhat self-explanatory.  I will be expanding this section o
 When using the legacy interface, file names will be output using the old, non-BIDS names and formats.  rapidtide can be forced to use the old style outputs with the "--legacyoutput" flag.
 
 Equivalence between BIDS and legacy outputs:
-""""""""""""""""""""""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. csv-table::
    :header: "BIDS style name", "Legacy name"
@@ -695,13 +698,13 @@ Equivalence between BIDS and legacy outputs:
 
 
 Examples:
-"""""""""
+^^^^^^^^^
 
 Rapidtide can do many things - as I've found more interesting things to do with time delay processing, it's gained new functions and options to support these new applications.  As a result, it can be a little hard to know what to use for a new experiment.  To help with that, I've decided to add this section to the manual to get you started.  It's broken up by type of data/analysis you might want to do.
 
 
 Removing low frequency physiological noise from resting state data
-''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 This is what I thought most people would use rapidtide for - finding and removing the low frequency (LFO) signal from an existing dataset.  This presupposes you have not made a simultaneous physiological recording (well, you may have, but it assumes you aren't using it).  For this, you can use a minimal set of options, since the defaults are mostly right.
 
@@ -714,7 +717,7 @@ The base command you'd use would be:
 This will do a fairly simple analysis.  First, the -L option means that rapidtide will prefilter the data to the LFO band (0.009-0.15Hz). It will then construct a regressor from the global mean of the signal in inputfmrifile (default behavior if no regressor is specified), and then use crosscorrelation to determine the time delay in each voxel.  The --refinepasses=3 option directs rapidtide to to perform the delay analysis 3 times, each time generating a new estimate of the global noise signal by aligning all of the timecourses in the data to bring the global signal in phase prior to averaging.  The --refineoffset flag recenters the peak of the delay distribution on zero during the refinement process, which should make datasets easier to compare.  After the three passes are complete, it will then use a GLM filter to remove a lagged copy of the final mean regressor that from the data - this denoised data will be in the file "outputname_filtereddata.nii.gz".  There will also a number of maps output with the prefix `"outputname_"` of delay, correlation strength and so on.
 
 Mapping long time delays in response to a gas challenge experiment:
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 Processing this sort of data requires a very different set of options from the previous case.  Instead of the distribution of delays you expect in healthy controls (a slightly skewed, somewhat normal distribution with a tail on the positive side, ranging from about -5 to 5 seconds), in this case, the maximum delay can be extremely long (100-120 seconds is not uncommon in stroke, moyamoya disesase, and atherosclerosis).  To do this, you need to radically change what options you use, not just the delay range, but a number of other options having to do with refinement and statistical measures.
 
@@ -734,7 +737,7 @@ The -noglm option disables data filtering.  If you are using rapidtide to estima
 
 
 Denoising NIRS data (NEW)
-'''''''''''''''''''''''''
+"""""""""""""""""""""""""
 
 When we started this whole research effort, I waw originally planning to denoise NIRS data, not fMRI data.  But one thing led to another, and the NIRS got derailed for the fMRI effort.  Now that we have some time to catch our breaths, and more importantly, we have access to some much higher quality NIRS data, this moved back to the front burner.  The majority of the work was already done, I just needed to account for a few qualities that make NIRS data different from fMRI data:
 
@@ -743,12 +746,11 @@ When we started this whole research effort, I waw originally planning to denoise
 * NIRS data is in some sense "calibrated" as relative micromolar changes in oxy-, deoxy-, and total hemoglobin concentration, so mean and/or variance normalizing the timecourses may not be right thing to do.  I've added in some new options to mess with normalizations.
 
 
-
 happy
-^^^^^
+-----
 
 Description:
-""""""""""""
+^^^^^^^^^^^^
 
 happy is a new addition to the rapidtide suite.  It's complementary to rapidtide - it's focussed on fast, cardiac signals in fMRI, rather than the slow, LFO signals we are usually looking at.  It's sort of a Frankenprogram - it has three distinct jobs, which are related, but are very distinct.
 

--- a/rapidtide/workflows/parser_funcs.py
+++ b/rapidtide/workflows/parser_funcs.py
@@ -7,16 +7,15 @@ import argparse
 import rapidtide.filter as tide_filt
 
 
-class indicatespecifiedAction(argparse.Action):
+class IndicateSpecifiedAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         setattr(namespace, self.dest, values)
-        setattr(namespace, self.dest+'_nondefault', True)
+        setattr(namespace, self.dest + "_nondefault", True)
+
 
 def setifnotset(thedict, thekey, theval):
-    try:
-        test = thedict[thekey + '_nondefault']
-    except KeyError:
-        print('overriding ' + thekey)
+    if (thekey + "_nondefault") not in thedict.keys():
+        print("overriding " + thekey)
         thedict[thekey] = theval
 
 
@@ -25,11 +24,11 @@ def is_valid_filespec(parser, arg):
     Check if argument is existing file.
     """
     if arg is None:
-        parser.error('No file specified')
+        parser.error("No file specified")
 
-    thesplit = arg.split(':')
+    thesplit = arg.split(":")
     if not op.isfile(thesplit[0]):
-        parser.error('The file {0} does not exist!'.format(thesplit[0]))
+        parser.error("The file {0} does not exist!".format(thesplit[0]))
 
     return arg
 
@@ -39,7 +38,7 @@ def is_valid_file(parser, arg):
     Check if argument is existing file.
     """
     if not op.isfile(arg) and arg is not None:
-        parser.error('The file {0} does not exist!'.format(arg))
+        parser.error("The file {0} does not exist!".format(arg))
 
     return arg
 
@@ -48,13 +47,13 @@ def invert_float(parser, arg):
     """
     Check if argument is float or auto.
     """
-    if arg != 'auto':
+    if arg != "auto":
         try:
             arg = float(arg)
         except parser.error:
             parser.error('Value {0} is not a float or "auto"'.format(arg))
 
-    if arg != 'auto':
+    if arg != "auto":
         arg = 1.0 / arg
     return arg
 
@@ -63,7 +62,7 @@ def is_float(parser, arg):
     """
     Check if argument is float or auto.
     """
-    if arg != 'auto':
+    if arg != "auto":
         try:
             arg = float(arg)
         except parser.error:
@@ -76,7 +75,7 @@ def is_int(parser, arg):
     """
     Check if argument is int or auto.
     """
-    if arg != 'auto':
+    if arg != "auto":
         try:
             arg = int(arg)
         except parser.error:
@@ -90,57 +89,80 @@ def is_range(parser, arg):
     Check if argument is min/max pair.
     """
     if arg is not None and len(arg) != 2:
-        parser.error('Argument must be min/max pair.')
+        parser.error("Argument must be min/max pair.")
     elif arg is not None and float(arg[0]) > float(arg[1]):
-        parser.error('Argument min must be lower than max.')
+        parser.error("Argument min must be lower than max.")
 
     return arg
 
-defaultfilterorder = 6
-defaultpadseconds = 30.0
+
+DEFAULT_FILTER_ORDER = 6
+DEFAULT_PAD_SECONDS = 30.0
+
+
 def addfilteropts(parser, filtertarget, details=False):
-    filt_opts = parser.add_argument_group('Filtering options')
-    filt_opts.add_argument('--filterband',
-                          dest='filterband',
-                          action='store',
-                          type=str,
-                          choices=['vlf', 'lfo', 'resp', 'cardiac', 'lfo_legacy'],
-                          help=('Filter ' + filtertarget + ' to specific band. '),
-                          default='lfo')
-    filt_opts.add_argument('--filterfreqs',
-                          dest='arbvec',
-                          action='store',
-                          nargs='+',
-                          type=lambda x: is_float(parser, x),
-                          metavar=('LOWERPASS UPPERPASS',
-                                   'LOWERSTOP UPPERSTOP'),
-                          help=('Filter ' + filtertarget + ' to retain LOWERPASS to '
-                                'UPPERPASS. LOWERSTOP and UPPERSTOP can also '
-                                'be specified, or will be calculated '
-                                'automatically. '),
-                          default=None)
+    filt_opts = parser.add_argument_group("Filtering options")
+    filt_opts.add_argument(
+        "--filterband",
+        dest="filterband",
+        action="store",
+        type=str,
+        choices=["vlf", "lfo", "resp", "cardiac", "lfo_legacy"],
+        help=("Filter " + filtertarget + " to specific band. "),
+        default="lfo",
+    )
+    filt_opts.add_argument(
+        "--filterfreqs",
+        dest="arbvec",
+        action="store",
+        nargs="+",
+        type=lambda x: is_float(parser, x),
+        metavar=("LOWERPASS UPPERPASS", "LOWERSTOP UPPERSTOP"),
+        help=(
+            "Filter " + filtertarget + " to retain LOWERPASS to "
+            "UPPERPASS. LOWERSTOP and UPPERSTOP can also "
+            "be specified, or will be calculated "
+            "automatically. "
+        ),
+        default=None,
+    )
     if details:
-        filt_opts.add_argument('--filtertype',
-                              dest='filtertype',
-                              action='store',
-                              type=str,
-                              choices=['trapezoidal', 'brickwall', 'butterworth'],
-                              help=('Filter ' + filtertarget + ' using a trapezoidal FFT filter (default), brickwall, or butterworth bandpass.'),
-                              default='trapezoidal')
-        filt_opts.add_argument('--butterorder',
-                             dest='filtorder',
-                             action='store',
-                             type=int,
-                             metavar='ORDER',
-                             help=('Set order of butterworth filter (if used).'),
-                             default=defaultfilterorder)
-        filt_opts.add_argument('--padseconds',
-                             dest='padseconds',
-                             action='store',
-                             type=float,
-                             metavar='SECONDS',
-                             help=('The number of seconds of padding to add to each end of a filtered timecourse. '),
-                             default=defaultpadseconds)
+        filt_opts.add_argument(
+            "--filtertype",
+            dest="filtertype",
+            action="store",
+            type=str,
+            choices=["trapezoidal", "brickwall", "butterworth"],
+            help=(
+                "Filter "
+                + filtertarget
+                + " using a trapezoidal FFT filter (default), brickwall, or "
+                "butterworth bandpass."
+            ),
+            default="trapezoidal",
+        )
+        filt_opts.add_argument(
+            "--butterorder",
+            dest="filtorder",
+            action="store",
+            type=int,
+            metavar="ORDER",
+            help=("Set order of butterworth filter (if used)."),
+            default=DEFAULT_FILTER_ORDER,
+        )
+        filt_opts.add_argument(
+            "--padseconds",
+            dest="padseconds",
+            action="store",
+            type=float,
+            metavar="SECONDS",
+            help=(
+                "The number of seconds of padding to add to each end of a "
+                "filtered timecourse. "
+            ),
+            default=DEFAULT_PAD_SECONDS,
+        )
+
 
 def postprocessfilteropts(args):
     # configure the filter
@@ -148,15 +170,15 @@ def postprocessfilteropts(args):
     try:
         thetype = args.filtertype
     except AttributeError:
-        args.filtertype = 'trapezoidal'
+        args.filtertype = "trapezoidal"
     try:
         theorder = args.filtorder
     except AttributeError:
-        args.filtorder = defaultfilterorder
+        args.filtorder = DEFAULT_FILTER_ORDER
     try:
         thepadseconds = args.padseconds
     except AttributeError:
-        args.filtertype = defaultpadseconds
+        args.filtertype = DEFAULT_PAD_SECONDS
 
     # if arbvec is set, we are going set up an arbpass filter
     if args.arbvec is not None:
@@ -164,82 +186,117 @@ def postprocessfilteropts(args):
             args.arbvec.append(args.arbvec[0] * 0.95)
             args.arbvec.append(args.arbvec[1] * 1.05)
         elif len(args.arbvec) != 4:
-            raise ValueError("Argument '--arb' must be either two "
-                             "or four floats.")
+            raise ValueError("Argument '--arb' must be either two or four "
+                             "floats.")
         # NOTE - this vector is LOWERPASS, UPPERPASS, LOWERSTOP, UPPERSTOP
         # setfreqs expects LOWERSTOP, LOWERPASS, UPPERPASS, UPPERSTOP
-        theprefilter = tide_filt.noncausalfilter('arb', transferfunc=args.filtertype)
-        theprefilter.setfreqs(args.arbvec[2], args.arbvec[0], args.arbvec[1], args.arbvec[3])
+        theprefilter = tide_filt.noncausalfilter(
+            "arb",
+            transferfunc=args.filtertype,
+        )
+        theprefilter.setfreqs(
+            args.arbvec[2], args.arbvec[0], args.arbvec[1], args.arbvec[3]
+        )
     else:
-        theprefilter = tide_filt.noncausalfilter(args.filterband, transferfunc=args.filtertype)
+        theprefilter = tide_filt.noncausalfilter(
+            args.filterband, transferfunc=args.filtertype
+        )
 
     # set the butterworth order
     theprefilter.setbutterorder(args.filtorder)
 
-    args.lowerstop, args.lowerpass, args.upperpass, args.upperstop = theprefilter.getfreqs()
+    (
+        args.lowerstop,
+        args.lowerpass,
+        args.upperpass,
+        args.upperstop,
+    ) = theprefilter.getfreqs()
 
     return args, theprefilter
 
 
 def addwindowopts(parser):
-    wfunc = parser.add_argument_group('Windowing options')
-    wfunc.add_argument('--windowfunc',
-                       dest='windowfunc',
-                       action='store',
-                       type=str,
-                       choices=['hamming', 'hann', 'blackmanharris', 'None'],
-                       help=('Window function to use prior to correlation. '
-                             'Options are hamming (default), hann, '
-                             'blackmanharris, and None. '),
-                       default='hamming')
+    wfunc = parser.add_argument_group("Windowing options")
+    wfunc.add_argument(
+        "--windowfunc",
+        dest="windowfunc",
+        action="store",
+        type=str,
+        choices=["hamming", "hann", "blackmanharris", "None"],
+        help=(
+            "Window function to use prior to correlation. "
+            "Options are hamming (default), hann, "
+            "blackmanharris, and None. "
+        ),
+        default="hamming",
+    )
 
 
 def addpermutationopts(parser):
     permutationmethod = parser.add_mutually_exclusive_group()
-    permutationmethod.add_argument('--permutationmethod',
-                          dest='permutationmethod',
-                          action='store',
-                          type=str,
-                          choices=['shuffle', 'phaserandom'],
-                          help=('Permutation method for significance testing.  Default is shuffle. '),
-                          default='shuffle')
-    parser.add_argument('--numnull',
-                         dest='numestreps',
-                         action='store',
-                         type=int,
-                         metavar='NREPS',
-                         help=('Estimate significance threshold by running '
-                               'NREPS null correlations (default is 10000, '
-                               'set to 0 to disable). '),
-                         default=10000)
-    parser.add_argument('--skipsighistfit',
-                         dest='dosighistfit',
-                         action='store_false',
-                         help=('Do not fit significance histogram with a '
-                               'Johnson SB function. '),
-                         default=True)
+    permutationmethod.add_argument(
+        "--permutationmethod",
+        dest="permutationmethod",
+        action="store",
+        type=str,
+        choices=["shuffle", "phaserandom"],
+        help=(
+            "Permutation method for significance testing.  "
+            "Default is shuffle."
+        ),
+        default="shuffle",
+    )
+    parser.add_argument(
+        "--numnull",
+        dest="numestreps",
+        action="store",
+        type=int,
+        metavar="NREPS",
+        help=(
+            "Estimate significance threshold by running "
+            "NREPS null correlations (default is 10000, "
+            "set to 0 to disable). "
+        ),
+        default=10000,
+    )
+    parser.add_argument(
+        "--skipsighistfit",
+        dest="dosighistfit",
+        action="store_false",
+        help=("Do not fit significance histogram with a Johnson SB function."),
+        default=True,
+    )
 
 
-
-def addsearchrangeopts(parser, details=False, defaultmin=-30.0, defaultmax=30.0):
-    parser.add_argument('--searchrange',
-                          dest='lag_extrema',
-                          action=indicatespecifiedAction,
-                          nargs=2,
-                          type=float,
-                          metavar=('LAGMIN', 'LAGMAX'),
-                          help=('Limit fit to a range of lags from LAGMIN to '
-                                'LAGMAX.  Default is -30.0 to 30.0 seconds. '),
-                          default=(defaultmin, defaultmax))
+def addsearchrangeopts(parser, details=False, defaultmin=-30.0,
+                       defaultmax=30.0):
+    parser.add_argument(
+        "--searchrange",
+        dest="lag_extrema",
+        action=IndicateSpecifiedAction,
+        nargs=2,
+        type=float,
+        metavar=("LAGMIN", "LAGMAX"),
+        help=(
+            "Limit fit to a range of lags from LAGMIN to "
+            "LAGMAX.  Default is -30.0 to 30.0 seconds. "
+        ),
+        default=(defaultmin, defaultmax),
+    )
     if details:
-        parser.add_argument('--fixdelay',
-                              dest='fixeddelayvalue',
-                              action='store',
-                              type=float,
-                              metavar='DELAYTIME',
-                              help=("Don't fit the delay time - set it to "
-                                    "DELAYTIME seconds for all voxels. "),
-                              default=None)
+        parser.add_argument(
+            "--fixdelay",
+            dest="fixeddelayvalue",
+            action="store",
+            type=float,
+            metavar="DELAYTIME",
+            help=(
+                "Don't fit the delay time - set it to "
+                "DELAYTIME seconds for all voxels. "
+            ),
+            default=None,
+        )
+
 
 def postprocesssearchrangeopts(args):
     # Additional argument parsing not handled by argparse
@@ -250,8 +307,10 @@ def postprocesssearchrangeopts(args):
         args.fixdelayvalue = None
     if args.fixeddelayvalue is not None:
         args.fixdelay = True
-        args.lag_extrema = (args.fixeddelayvalue - 10.0,
-                               args.fixeddelayvalue + 10.0)
+        args.lag_extrema = (
+            args.fixeddelayvalue - 10.0,
+            args.fixeddelayvalue + 10.0
+        )
     else:
         args.fixdelay = False
 
@@ -268,17 +327,21 @@ def postprocesssearchrangeopts(args):
 
 
 def addtimerangeopts(parser):
-    parser.add_argument('--timerange',
-                         dest='timerange',
-                         action='store',
-                         nargs=2,
-                         type=int,
-                         metavar=('START', 'END'),
-                         help=('Limit analysis to data between timepoints '
-                               'START and END in the input file. If END is set to -1, '
-                               'analysis will go to the last timepoint.  Negative values '
-                               'of START will be set to 0. Default is to use all timepoints.'),
-                         default=(-1, -1))
+    parser.add_argument(
+        "--timerange",
+        dest="timerange",
+        action="store",
+        nargs=2,
+        type=int,
+        metavar=("START", "END"),
+        help=(
+            "Limit analysis to data between timepoints "
+            "START and END in the input file. If END is set to -1, "
+            "analysis will go to the last timepoint.  Negative values "
+            "of START will be set to 0. Default is to use all timepoints."
+        ),
+        default=(-1, -1),
+    )
 
 
 def postprocesstimerangeopts(args):
@@ -289,21 +352,18 @@ def postprocesstimerangeopts(args):
         args.endpoint = int(args.timerange[1])
     return args
 
+
 def addsimilarityopts(parser):
     parser.add_argument(
-        '--mutualinfosmoothingtime',
-        dest='smoothingtime',
-        action='store',
+        "--mutualinfosmoothingtime",
+        dest="smoothingtime",
+        action="store",
         type=float,
-        metavar='TAU',
-        help=('Time constant of a temporal smoothing function to apply to the mutual information function. '
-              'Default is 3.0 seconds.  TAU <=0.0 disables smoothing.'),
-        default=3.0)
-
-
-
-
-
-
-
-
+        metavar="TAU",
+        help=(
+            "Time constant of a temporal smoothing function to apply to the "
+            "mutual information function. "
+            "Default is 3.0 seconds.  TAU <=0.0 disables smoothing."
+        ),
+        default=3.0,
+    )

--- a/rapidtide/workflows/rapidtide_parser.py
+++ b/rapidtide/workflows/rapidtide_parser.py
@@ -21,176 +21,223 @@
 #
 #
 #
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 import argparse
+import logging
 import sys
 
+import nibabel as nib
 import numpy as np
 
 import rapidtide.filter as tide_filt
 import rapidtide.io as tide_io
 import rapidtide.util as tide_util
-
-import nibabel as nib
-
 import rapidtide.workflows.parser_funcs as pf
 
-'''class indicatespecifiedAction(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
-        setattr(namespace, self.dest, values)
-        setattr(namespace, self.dest+'_nondefault', True)
 
-def setifnotset(thedict, thekey, theval):
-    try:
-        test = thedict[thekey + '_nondefault']
-    except KeyError:
-        print('overriding ' + thekey)
-        thedict[thekey] = theval'''
+LGR = logging.getLogger(__name__)
 
 
 def _get_parser():
     """
     Argument parser for rapidtide
     """
-    parser = argparse.ArgumentParser(prog='rapidtide',
-                                     description='Perform a RIPTiDe time delay analysis on a dataset.',
-                                     usage='%(prog)s in_file outputname [options]')
+    parser = argparse.ArgumentParser(
+        prog="rapidtide",
+        description=("Perform a RIPTiDe time delay analysis on a dataset."),
+        usage="%(prog)s in_file outputname [options]",
+    )
 
     # Required arguments
     parser.add_argument(
-            'in_file',
-            type=lambda x: pf.is_valid_file(parser, x),
-            help='The input data file (BOLD fmri file or NIRS text file)')
+        "in_file",
+        type=lambda x: pf.is_valid_file(parser, x),
+        help="The input data file (BOLD fMRI file or NIRS text file)",
+    )
     parser.add_argument(
-            'outputname',
-            help='The root name for the output files.  For BIDS compliance, this can only contain valid BIDS entities from the source data.')
+        "outputname",
+        type=str,
+        help=(
+            "The root name for the output files.  "
+            "For BIDS compliance, this can only contain valid BIDS entities "
+            "from the source data."
+        ),
+    )
 
     # Analysis types
-    analysis_type = parser.add_argument_group('Analysis type').add_mutually_exclusive_group()
+    analysis_type = parser.add_argument_group(
+        title="Analysis type",
+        description=(
+            "Single arguments that change default values for many "
+            "arguments. "
+            "Any parameter set by an analysis type can be overridden "
+            "by setting that parameter explicitly. "
+            "Analysis types are mutually exclusive with one another, "
+            "but may be combined with 'Macros'."
+        ),
+    ).add_mutually_exclusive_group()
     analysis_type.add_argument(
-            '--denoising',
-            dest='denoising',
-            action='store_true',
-            help=('Preset for hemodynamic denoising - this is a macro that '
-                  'sets lagmin=-15.0, lagmax=15.0, passes=3, despeckle_passes=4, '
-                  'refineoffset=True, peakfittype=fastquad, doglmfilt=True. '
-                  'Any of these options can be overridden with the appropriate '
-                  'additional arguments'),
-            default=False)
+        "--denoising",
+        dest="denoising",
+        action="store_true",
+        help=(
+            "Preset for hemodynamic denoising - this is a macro that "
+            "sets lagmin=-15.0, lagmax=15.0, passes=3, despeckle_passes=4, "
+            "refineoffset=True, peakfittype=fastquad, doglmfilt=True. "
+            "Any of these options can be overridden with the appropriate "
+            "additional arguments"
+        ),
+        default=False,
+    )
     analysis_type.add_argument(
-            '--delaymapping',
-            dest='delaymapping',
-            action='store_true',
-            help=('Preset for delay mapping analysis - this is a macro that '
-                  'sets lagmin=-10.0, lagmax=30.0, passes=3, despeckle_passes=4, '
-                  'refineoffset=True, pickleft=True, limitoutput=True, doglmfilt=False. '
-                  'Any of these options can be overridden with the appropriate '
-                  'additional arguments'),
-            default=False)
+        "--delaymapping",
+        dest="delaymapping",
+        action="store_true",
+        help=(
+            "Preset for delay mapping analysis - this is a macro that "
+            "sets lagmin=-10.0, lagmax=30.0, passes=3, despeckle_passes=4, "
+            "refineoffset=True, pickleft=True, limitoutput=True, "
+            "doglmfilt=False. "
+            "Any of these options can be overridden with the appropriate "
+            "additional arguments"
+        ),
+        default=False,
+    )
 
     # Macros
-    macros = parser.add_argument_group('Macros').add_mutually_exclusive_group()
+    macros = parser.add_argument_group(
+        title="Macros",
+        description=(
+            "Single arguments that change default values for many "
+            "arguments. "
+            "Macros override individually set parameters. "
+            "Macros are mutually exclusive with one another, but may "
+            "be combined with 'Analysis Types'."
+        ),
+    ).add_mutually_exclusive_group()
     macros.add_argument(
-            '--venousrefine',
-            dest='venousrefine',
-            action='store_true',
-            help=('This is a macro that sets --lagminthresh=2.5, '
-                  '--lagmaxthresh=6.0, --ampthresh=0.5, and '
-                  '--refineupperlag to bias refinement towards '
-                  'voxels in the draining vasculature for an '
-                  'fMRI scan. '),
-            default=False)
+        "--venousrefine",
+        dest="venousrefine",
+        action="store_true",
+        help=(
+            "This is a macro that sets --lagminthresh=2.5, "
+            "--lagmaxthresh=6.0, --ampthresh=0.5, and "
+            "--refineupperlag to bias refinement towards "
+            "voxels in the draining vasculature for an "
+            "fMRI scan."
+        ),
+        default=False,
+    )
     macros.add_argument(
-            '--nirs',
-            dest='nirs',
-            action='store_true',
-            help=('This is a NIRS analysis - this is a macro that '
-                  'sets --nothresh, --preservefiltering, '
-                  '--refineprenorm=var, --ampthresh=0.7, and '
-                  '--lagminthresh=0.1. '),
-            default=False)
+        "--nirs",
+        dest="nirs",
+        action="store_true",
+        help=(
+            "This is a NIRS analysis - this is a macro that "
+            "sets --nothresh, --preservefiltering, "
+            "--refineprenorm=var, --ampthresh=0.7, and "
+            "--lagminthresh=0.1. "
+        ),
+        default=False,
+    )
 
     # Preprocessing options
-    preproc = parser.add_argument_group('Preprocessing options')
+    preproc = parser.add_argument_group("Preprocessing options")
     realtr = preproc.add_mutually_exclusive_group()
     realtr.add_argument(
-            '--datatstep',
-            dest='realtr',
-            action='store',
-            metavar='TSTEP',
-            type=lambda x: pf.is_float(parser, x),
-            help=('Set the timestep of the data file to TSTEP. '
-                  'This will override the TR in an '
-                  'fMRI file. NOTE: if using data from a text '
-                  'file, for example with NIRS data, using one '
-                  'of these options is mandatory. '),
-            default='auto')
+        "--datatstep",
+        dest="realtr",
+        action="store",
+        metavar="TSTEP",
+        type=lambda x: pf.is_float(parser, x),
+        help=(
+            "Set the timestep of the data file to TSTEP. "
+            "This will override the TR in an "
+            "fMRI file. NOTE: if using data from a text "
+            "file, for example with NIRS data, using one "
+            "of these options is mandatory. "
+        ),
+        default="auto",
+    )
     realtr.add_argument(
-            '--datafreq',
-            dest='realtr',
-            action='store',
-            metavar='FREQ',
-            type=lambda x: pf.invert_float(parser, x),
-            help=('Set the timestep of the data file to 1/FREQ. '
-                  'This will override the TR in an '
-                  'fMRI file. NOTE: if using data from a text '
-                  'file, for example with NIRS data, using one '
-                  'of these options is mandatory. '),
-            default='auto')
+        "--datafreq",
+        dest="realtr",
+        action="store",
+        metavar="FREQ",
+        type=lambda x: pf.invert_float(parser, x),
+        help=(
+            "Set the timestep of the data file to 1/FREQ. "
+            "This will override the TR in an "
+            "fMRI file. NOTE: if using data from a text "
+            "file, for example with NIRS data, using one "
+            "of these options is mandatory. "
+        ),
+        default="auto",
+    )
     preproc.add_argument(
-            '--noantialias',
-             dest='antialias',
-             action='store_false',
-             help='Disable antialiasing filter. ',
-             default=True)
+        "--noantialias",
+        dest="antialias",
+        action="store_false",
+        help="Disable antialiasing filter. ",
+        default=True,
+    )
     preproc.add_argument(
-            '--invert',
-             dest='invertregressor',
-             action='store_true',
-             help=('Invert the sign of the regressor before '
-                   'processing. '),
-             default=False)
+        "--invert",
+        dest="invertregressor",
+        action="store_true",
+        help=("Invert the sign of the regressor before processing."),
+        default=False,
+    )
     preproc.add_argument(
-            '--interptype',
-             dest='interptype',
-             action='store',
-             type=str,
-             choices=['univariate', 'cubic', 'quadratic'],
-             help=("Use specified interpolation type. Options "
-                   "are 'cubic','quadratic', and 'univariate' "
-                   "(default). "),
-             default='univariate')
+        "--interptype",
+        dest="interptype",
+        action="store",
+        type=str,
+        choices=["univariate", "cubic", "quadratic"],
+        help=(
+            "Use specified interpolation type. Options "
+            "are 'cubic', 'quadratic', and 'univariate' "
+            "(default). "
+        ),
+        default="univariate",
+    )
     preproc.add_argument(
-            '--offsettime',
-             dest='offsettime',
-             action='store',
-             type=float,
-             metavar='OFFSETTIME',
-             help='Apply offset OFFSETTIME to the lag regressors. ',
-             default=0.0)
+        "--offsettime",
+        dest="offsettime",
+        action="store",
+        type=float,
+        metavar="OFFSETTIME",
+        help="Apply offset OFFSETTIME to the lag regressors.",
+        default=0.0,
+    )
     preproc.add_argument(
-            '--autosync',
-             dest='autosync',
-             action='store_true',
-             help=('Estimate and apply the initial offsettime of an external regressor using the global "'
-                   'crosscorrelation. Overrides offsettime if present.'),
-             default=False)
+        "--autosync",
+        dest="autosync",
+        action="store_true",
+        help=(
+            "Estimate and apply the initial offsettime of an external "
+            "regressor using the global crosscorrelation. "
+            "Overrides offsettime if present."
+        ),
+        default=False,
+    )
 
     # Add filter options
-    pf.addfilteropts(parser, 'data and regressors', details=True)
+    pf.addfilteropts(parser, "data and regressors", details=True)
 
     # Add permutation options
     pf.addpermutationopts(parser)
 
-    '''permutationmethod = preproc.add_mutually_exclusive_group()
+    """permutationmethod = preproc.add_mutually_exclusive_group()
     permutationmethod.add_argument(
             '--permutationmethod',
             dest='permutationmethod',
             action='store',
             type=str,
             choices=['shuffle', 'phaserandom'],
-            help=('Permutation method for significance testing.  Default is shuffle. '),
+            help=('Permutation method for significance testing.  '
+                  'Default is shuffle. '),
             default='shuffle')
     preproc.add_argument(
             '--numnull',
@@ -210,686 +257,933 @@ def _get_parser():
             action='store_false',
             help=('Do not fit significance histogram with a '
                'Johnson SB function. '),
-            default=True)'''
+            default=True)"""
 
     wfunc = preproc.add_mutually_exclusive_group()
     wfunc.add_argument(
-            '--windowfunc',
-            dest='windowfunc',
-            action='store',
-            type=str,
-            choices=['hamming', 'hann', 'blackmanharris', 'None'],
-            help=('Window function to use prior to correlation. '
-                 'Options are hamming (default), hann, '
-                 'blackmanharris, and None. '),
-            default='hamming')
+        "--windowfunc",
+        dest="windowfunc",
+        action="store",
+        type=str,
+        choices=["hamming", "hann", "blackmanharris", "None"],
+        help=(
+            "Window function to use prior to correlation. "
+            "Options are hamming (default), hann, "
+            "blackmanharris, and None."
+        ),
+        default="hamming",
+    )
     wfunc.add_argument(
-            '--nowindow',
-            dest='windowfunc',
-            action='store_const',
-            const='None',
-            help='Disable precorrelation windowing. ',
-            default='hamming')
+        "--nowindow",
+        dest="windowfunc",
+        action="store_const",
+        const="None",
+        help="Disable precorrelation windowing.",
+        default="hamming",
+    )
 
     preproc.add_argument(
-            '--detrendorder',
-             dest='detrendorder',
-             action='store',
-             type=int,
-             metavar='ORDER',
-             help=('Set order of trend removal (0 to disable, default is 1 - linear). '),
-             default=3)
+        "--detrendorder",
+        dest="detrendorder",
+        action="store",
+        type=int,
+        metavar="ORDER",
+        help=(
+            "Set order of trend removal (0 to disable, "
+            "default is 1 - linear)."
+        ),
+        default=3,
+    )
     preproc.add_argument(
-            '--spatialfilt',
-             dest='gausssigma',
-             action='store',
-             type=float,
-             metavar='GAUSSSIGMA',
-             help=('Spatially filter fMRI data prior to analysis '
-                   'using GAUSSSIGMA in mm. '),
-             default=0.0)
+        "--spatialfilt",
+        dest="gausssigma",
+        action="store",
+        type=float,
+        metavar="GAUSSSIGMA",
+        help=(
+            "Spatially filter fMRI data prior to analysis "
+            "using GAUSSSIGMA in mm."
+        ),
+        default=0.0,
+    )
     preproc.add_argument(
-            '--globalmean',
-            dest='useglobalref',
-            action='store_true',
-            help=('Generate a global mean regressor and use that '
-               'as the reference regressor.  If no external regressor is specified, this'
-               'is enatbled by default. '),
-            default=False)
+        "--globalmean",
+        dest="useglobalref",
+        action="store_true",
+        help=(
+            "Generate a global mean regressor and use that as the reference "
+            "regressor.  If no external regressor is specified, this "
+            "is enabled by default."
+        ),
+        default=False,
+    )
 
     globalmethod = preproc.add_mutually_exclusive_group()
     globalmethod.add_argument(
-            '--globalmaskmethod',
-            dest='globalmaskmethod',
-            action='store',
-            type=str,
-            choices=['mean', 'variance'],
-            help=('Select whether to use timecourse mean (default) or variance to mask voxels prior to generating global mean. '),
-            default='mean')
+        "--globalmaskmethod",
+        dest="globalmaskmethod",
+        action="store",
+        type=str,
+        choices=["mean", "variance"],
+        help=(
+            "Select whether to use timecourse mean (default) or variance to "
+            "mask voxels prior to generating global mean."
+        ),
+        default="mean",
+    )
 
     preproc.add_argument(
-            '--globalmeaninclude',
-            dest='globalmeanincludespec',
-            metavar='MASK[:VALSPEC]',
-            help=('Only use voxels in NAME for global regressor '
-               'generation (if VALSPEC is given, only voxels '
-               'with integral values listed in VALSPEC are used). '),
-            default=None)
+        "--globalmeaninclude",
+        dest="globalmeanincludespec",
+        metavar="MASK[:VALSPEC]",
+        help=(
+            "Only use voxels in mask file NAME for global regressor "
+            "generation (if VALSPEC is given, only voxels "
+            "with integral values listed in VALSPEC are used)."
+        ),
+        default=None,
+    )
     preproc.add_argument(
-            '--globalmeanexclude',
-            dest='globalmeanexcludespec',
-            metavar='MASK[:VALSPEC]',
-            help=('Do not use voxels in NAME for global regressor '
-               'generation (if VALSPEC is given, only voxels '
-               'with integral values listed in VALSPEC are excluded). '),
-            default=None)
+        "--globalmeanexclude",
+        dest="globalmeanexcludespec",
+        metavar="MASK[:VALSPEC]",
+        help=(
+            "Do not use voxels in mask file NAME for global regressor "
+            "generation (if VALSPEC is given, only voxels "
+            "with integral values listed in VALSPEC are excluded)."
+        ),
+        default=None,
+    )
     preproc.add_argument(
-            '--motionfile',
-            dest='motionfilespec',
-            metavar='MASK[:VALSPEC]',
-            help=('Read 6 columns of motion regressors out of MOTFILE text file. '
-               '(with timepoints rows) and regress their derivatives '
-               'and delayed derivatives out of the data prior to analysis. '
-               'If COLSPEC is present, use the comma separated list of ranges to '
-               'specify X, Y, Z, RotX, RotY, and RotZ, in that order.  For  '
-               'example, :3-5,7,0,9 would use columns 3, 4, 5, 7, 0 and 9 '
-               'for X, Y, Z, RotX, RotY, RotZ, respectively. '),
-            default=None)
+        "--motionfile",
+        dest="motionfilespec",
+        metavar="MASK[:VALSPEC]",
+        help=(
+            "Read 6 columns of motion regressors out of MOTFILE text file. "
+            "(with timepoints rows) and regress their derivatives "
+            "and delayed derivatives out of the data prior to analysis. "
+            "If COLSPEC is present, use the comma separated list of ranges to "
+            "specify X, Y, Z, RotX, RotY, and RotZ, in that order.  For  "
+            "example, :3-5,7,0,9 would use columns 3, 4, 5, 7, 0 and 9 "
+            "for X, Y, Z, RotX, RotY, RotZ, respectively."
+        ),
+        default=None,
+    )
     preproc.add_argument(
-            '--motpos',
-            dest='mot_pos',
-            action='store_true',
-            help=('Toggle whether displacement regressors will be used in motion regression. Default is False. '),
-            default=False)
+        "--motpos",
+        dest="mot_pos",
+        action="store_true",
+        help=(
+            "Toggle whether displacement regressors will be used in motion "
+            "regression. Default is False. "
+        ),
+        default=False,
+    )
     preproc.add_argument(
-            '--motderiv',
-            dest='mot_deriv',
-            action='store_false',
-            help=('Toggle whether derivatives will be used in motion regression.  Default is True. '),
-            default=True)
+        "--motderiv",
+        dest="mot_deriv",
+        action="store_false",
+        help=(
+            "Toggle whether derivatives will be used in motion regression.  "
+            "Default is True. "
+        ),
+        default=True,
+    )
     preproc.add_argument(
-            '--motdelayderiv',
-            dest='mot_delayderiv',
-            action='store_true',
-            help=('Toggle whether delayed derivative regressors will be used in motion regression.  Default is False. '),
-            default=False)
-
-
+        "--motdelayderiv",
+        dest="mot_delayderiv",
+        action="store_true",
+        help=(
+            "Toggle whether delayed derivative regressors will be used in "
+            "motion regression.  Default is False. "
+        ),
+        default=False,
+    )
     preproc.add_argument(
-            '--meanscale',
-            dest='meanscaleglobal',
-            action='store_true',
-            help=('Mean scale regressors during global mean '
-               'estimation. '),
-            default=False)
+        "--meanscale",
+        dest="meanscaleglobal",
+        action="store_true",
+        help=("Mean scale regressors during global mean estimation."),
+        default=False,
+    )
     preproc.add_argument(
-            '--slicetimes',
-            dest='slicetimes',
-            action='store',
-            type=lambda x: pf.is_valid_file(parser, x),
-            metavar='FILE',
-            help=('Apply offset times from FILE to each slice in '
-               'the dataset. '),
-            default=None)
+        "--slicetimes",
+        dest="slicetimes",
+        action="store",
+        type=lambda x: pf.is_valid_file(parser, x),
+        metavar="FILE",
+        help=("Apply offset times from FILE to each slice in the dataset."),
+        default=None,
+    )
     preproc.add_argument(
-            '--numskip',
-            dest='preprocskip',
-            action='store',
-            type=int,
-            metavar='SKIP',
-            help=('SKIP TRs were previously deleted during '
-               'preprocessing (e.g. if you have done your preprocessing '
-               'in FSL and set dummypoints to a nonzero value.) Default is 0. '),
-            default=0)
+        "--numskip",
+        dest="preprocskip",
+        action="store",
+        type=int,
+        metavar="SKIP",
+        help=(
+            "SKIP TRs were previously deleted during "
+            "preprocessing (e.g. if you have done your preprocessing "
+            "in FSL and set dummypoints to a nonzero value.) Default is 0. "
+        ),
+        default=0,
+    )
     preproc.add_argument(
-            '--timerange',
-            dest='timerange',
-            action='store',
-            nargs=2,
-            type=int,
-            metavar=('START', 'END'),
-            help=('Limit analysis to data between timepoints '
-               'START and END in the fmri file. If END is set to -1, '
-               'analysis will go to the last timepoint.  Negative values '
-               'of START will be set to 0. Default is to use all timepoints.'),
-            default=(-1, -1))
+        "--timerange",
+        dest="timerange",
+        action="store",
+        nargs=2,
+        type=int,
+        metavar=("START", "END"),
+        help=(
+            "Limit analysis to data between timepoints "
+            "START and END in the fmri file. If END is set to -1, "
+            "analysis will go to the last timepoint.  Negative values "
+            "of START will be set to 0. Default is to use all timepoints."
+        ),
+        default=(-1, -1),
+    )
     preproc.add_argument(
-            '--nothresh',
-            dest='nothresh',
-            action='store_true',
-            help=('Disable voxel intensity threshold (especially '
-               'useful for NIRS data). '),
-            default=False)
+        "--nothresh",
+        dest="nothresh",
+        action="store_true",
+        help=(
+            "Disable voxel intensity threshold (especially useful for NIRS "
+            "data)."
+        ),
+        default=False,
+    )
 
     # Correlation options
-    corr = parser.add_argument_group('Correlation options')
+    corr = parser.add_argument_group("Correlation options")
     corr.add_argument(
-            '--oversampfac',
-            dest='oversampfactor',
-            action='store',
-            type=int,
-            metavar='OVERSAMPFAC',
-            help=('Oversample the fMRI data by the following '
-                'integral factor.  Set to -1 for automatic selection (default). '),
-            default=-1)
+        "--oversampfac",
+        dest="oversampfactor",
+        action="store",
+        type=int,
+        metavar="OVERSAMPFAC",
+        help=(
+            "Oversample the fMRI data by the following "
+            "integral factor.  Set to -1 for automatic selection (default)."
+        ),
+        default=-1,
+    )
     corr.add_argument(
-            '--regressor',
-            dest='regressorfile',
-            action='store',
-            type=lambda x: pf.is_valid_file(parser, x),
-            metavar='FILE',
-            help=('Read the initial probe regressor from file FILE (if not '
-                'specified, generate and use the global regressor). '),
-            default=None)
+        "--regressor",
+        dest="regressorfile",
+        action="store",
+        type=lambda x: pf.is_valid_file(parser, x),
+        metavar="FILE",
+        help=(
+            "Read the initial probe regressor from file FILE (if not "
+            "specified, generate and use the global regressor)."
+        ),
+        default=None,
+    )
 
     reg_group = corr.add_mutually_exclusive_group()
     reg_group.add_argument(
-            '--regressorfreq',
-            dest='inputfreq',
-            action='store',
-            type=lambda x: pf.is_float(parser, x),
-            metavar='FREQ',
-            help=('Probe regressor in file has sample '
-                 'frequency FREQ (default is 1/tr) '
-                 'NB: --regressorfreq and --regressortstep) '
-                 'are two ways to specify the same thing. '),
-            default='auto')
+        "--regressorfreq",
+        dest="inputfreq",
+        action="store",
+        type=lambda x: pf.is_float(parser, x),
+        metavar="FREQ",
+        help=(
+            "Probe regressor in file has sample "
+            "frequency FREQ (default is 1/tr) "
+            "NB: --regressorfreq and --regressortstep) "
+            "are two ways to specify the same thing."
+        ),
+        default="auto",
+    )
     reg_group.add_argument(
-            '--regressortstep',
-            dest='inputfreq',
-            action='store',
-            type=lambda x: pf.invert_float(parser, x),
-            metavar='TSTEP',
-            help=('Probe regressor in file has sample '
-                 'frequency FREQ (default is 1/tr) '
-                 'NB: --regressorfreq and --regressortstep) '
-                 'are two ways to specify the same thing. '),
-            default='auto')
+        "--regressortstep",
+        dest="inputfreq",
+        action="store",
+        type=lambda x: pf.invert_float(parser, x),
+        metavar="TSTEP",
+        help=(
+            "Probe regressor in file has sample "
+            "frequency FREQ (default is 1/tr) "
+            "NB: --regressorfreq and --regressortstep) "
+            "are two ways to specify the same thing."
+        ),
+        default="auto",
+    )
 
     corr.add_argument(
-            '--regressorstart',
-            dest='inputstarttime',
-            action='store',
-            type=float,
-            metavar='START',
-            help=('The time delay in seconds into the regressor '
-                'file, corresponding in the first TR of the fMRI '
-                'file (default is 0.0). '),
-            default=0.)
+        "--regressorstart",
+        dest="inputstarttime",
+        action="store",
+        type=float,
+        metavar="START",
+        help=(
+            "The time delay in seconds into the regressor "
+            "file, corresponding in the first TR of the fMRI "
+            "file (default is 0.0)."
+        ),
+        default=0.0,
+    )
 
     cc_group = corr.add_mutually_exclusive_group()
     cc_group.add_argument(
-            '--corrweighting',
-            dest='corrweighting',
-            action='store',
-            type=str,
-            choices=['None', 'phat', 'liang', 'eckart'],
-            help=('Method to use for cross-correlation '
-                'weighting. Default is "None". '),
-            default='None')
+        "--corrweighting",
+        dest="corrweighting",
+        action="store",
+        type=str,
+        choices=["None", "phat", "liang", "eckart"],
+        help=(
+            "Method to use for cross-correlation weighting. "
+            "Default is 'None'."
+        ),
+        default="None",
+    )
 
     mask_group = corr.add_mutually_exclusive_group()
     mask_group.add_argument(
-            '--corrmaskthresh',
-            dest='corrmaskthreshpct',
-            action='store',
-            type=float,
-            metavar='PCT',
-            help=('Do correlations in voxels where the mean '
-                  'exceeds this percentage of the robust max '
-                  '(default is 1.0). '),
-            default=1.0)
+        "--corrmaskthresh",
+        dest="corrmaskthreshpct",
+        action="store",
+        type=float,
+        metavar="PCT",
+        help=(
+            "Do correlations in voxels where the mean "
+            "exceeds this percentage of the robust max "
+            "(default is 1.0). "
+        ),
+        default=1.0,
+    )
     mask_group.add_argument(
-            '--corrmask',
-            dest='corrmaskincludespec',
-            metavar='MASK[:VALSPEC]',
-            help=('Only do correlations in nonzero voxels in NAME '
-                  '(if VALSPEC is given, only voxels '
-                  'with integral values listed in VALSPEC are used). '),
-            default=None)
+        "--corrmask",
+        dest="corrmaskincludespec",
+        metavar="MASK[:VALSPEC]",
+        help=(
+            "Only do correlations in nonzero voxels in NAME "
+            "(if VALSPEC is given, only voxels "
+            "with integral values listed in VALSPEC are used). "
+        ),
+        default=None,
+    )
     corr.add_argument(
-            '--similaritymetric',
-            dest='similaritymetric',
-            action='store',
-            type=str,
-            choices=['correlation', 'mutualinfo', 'hybrid'],
-            help=('Similarity metric for finding delay values.  Choices are "correlation", '
-                '"mutualinfo", and "hybrid" (default).'),
-            default='hybrid')
+        "--similaritymetric",
+        dest="similaritymetric",
+        action="store",
+        type=str,
+        choices=["correlation", "mutualinfo", "hybrid"],
+        help=(
+            "Similarity metric for finding delay values.  "
+            "Choices are 'correlation', 'mutualinfo', and 'hybrid' (default)."
+        ),
+        default="hybrid",
+    )
     corr.add_argument(
-            '--mutualinfosmoothingtime',
-            dest='smoothingtime',
-            action='store',
-            type=float,
-            metavar='TAU',
-            help=('Time constant of a temporal smoothing function to apply to the mutual information function. '
-                  'Default is 3.0 seconds.  TAU <=0.0 disables smoothing.'),
-            default=3.0)
-
+        "--mutualinfosmoothingtime",
+        dest="smoothingtime",
+        action="store",
+        type=float,
+        metavar="TAU",
+        help=(
+            "Time constant of a temporal smoothing function to apply to the "
+            "mutual information function. "
+            "Default is 3.0 seconds.  "
+            "TAU <=0.0 disables smoothing."
+        ),
+        default=3.0,
+    )
 
     # Correlation fitting options
-    corr_fit = parser.add_argument_group('Correlation fitting options')
+    corr_fit = parser.add_argument_group("Correlation fitting options")
 
     fixdelay = corr_fit.add_mutually_exclusive_group()
     fixdelay.add_argument(
-            '--fixdelay',
-            dest='fixeddelayvalue',
-            action='store',
-            type=float,
-            metavar='DELAYTIME',
-            help=("Don't fit the delay time - set it to "
-                "DELAYTIME seconds for all voxels. "),
-            default=None)
+        "--fixdelay",
+        dest="fixeddelayvalue",
+        action="store",
+        type=float,
+        metavar="DELAYTIME",
+        help=(
+            "Don't fit the delay time - set it to DELAYTIME seconds for all "
+            "voxels."
+        ),
+        default=None,
+    )
     fixdelay.add_argument(
-            '--searchrange',
-            dest='lag_extrema',
-            action=pf.indicatespecifiedAction,
-            nargs=2,
-            type=float,
-            metavar=('LAGMIN', 'LAGMAX'),
-            help=('Limit fit to a range of lags from LAGMIN to '
-                'LAGMAX.  Default is -30.0 to 30.0 seconds. '),
-            default=(-30.0, 30.0))
+        "--searchrange",
+        dest="lag_extrema",
+        action=pf.IndicateSpecifiedAction,
+        nargs=2,
+        type=float,
+        metavar=("LAGMIN", "LAGMAX"),
+        help=(
+            "Limit fit to a range of lags from LAGMIN to "
+            "LAGMAX.  Default is -30.0 to 30.0 seconds. "
+        ),
+        default=(-30.0, 30.0),
+    )
     corr_fit.add_argument(
-            '--sigmalimit',
-            dest='widthlimit',
-            action='store',
-            type=float,
-            metavar='SIGMALIMIT',
-            help=('Reject lag fits with linewidth wider than '
-                'SIGMALIMIT Hz. Default is 100.0. '),
-            default=100.0)
+        "--sigmalimit",
+        dest="widthlimit",
+        action="store",
+        type=float,
+        metavar="SIGMALIMIT",
+        help=(
+            "Reject lag fits with linewidth wider than "
+            "SIGMALIMIT Hz. Default is 100.0."
+        ),
+        default=100.0,
+    )
     corr_fit.add_argument(
-            '--bipolar',
-            dest='bipolar',
-            action='store_true',
-            help=('Bipolar mode - match peak correlation '
-                'ignoring sign. '),
-            default=False)
+        "--bipolar",
+        dest="bipolar",
+        action="store_true",
+        help=("Bipolar mode - match peak correlation ignoring sign."),
+        default=False,
+    )
     corr_fit.add_argument(
-            '--nofitfilt',
-            dest='zerooutbadfit',
-            action='store_false',
-            help=('Do not zero out peak fit values if fit '
-                'fails. '),
-            default=True)
+        "--nofitfilt",
+        dest="zerooutbadfit",
+        action="store_false",
+        help=("Do not zero out peak fit values if fit fails."),
+        default=True,
+    )
     corr_fit.add_argument(
-            '--peakfittype',
-            dest='peakfittype',
-            action='store',
-            type=str,
-            choices=['gauss', 'fastgauss', 'quad', 'fastquad', 'COM', 'None'],
-            help=("Method for fitting the peak of the similarity function "
-                "(default is 'gauss'). 'quad' and 'fastquad' use a "
-                "quadratic fit.  Faster but not as well "
-                "tested. "),
-            default='gauss')
+        "--peakfittype",
+        dest="peakfittype",
+        action="store",
+        type=str,
+        choices=["gauss", "fastgauss", "quad", "fastquad", "COM", "None"],
+        help=(
+            "Method for fitting the peak of the similarity function "
+            "(default is 'gauss'). 'quad' and 'fastquad' use a quadratic fit. "
+            "Faster but not as well tested. "
+        ),
+        default="gauss",
+    )
     corr_fit.add_argument(
-            '--despecklepasses',
-            dest='despeckle_passes',
-            action=pf.indicatespecifiedAction,
-            type=int,
-            metavar='PASSES',
-            help=('Detect and refit suspect correlations to '
-                'disambiguate peak locations in PASSES '
-                'passes.  Default is to perform 4 passes. '
-                'Set to 0 to disable. '),
-            default=4)
+        "--despecklepasses",
+        dest="despeckle_passes",
+        action=pf.IndicateSpecifiedAction,
+        type=int,
+        metavar="PASSES",
+        help=(
+            "Detect and refit suspect correlations to "
+            "disambiguate peak locations in PASSES "
+            "passes.  Default is to perform 4 passes. "
+            "Set to 0 to disable."
+        ),
+        default=4,
+    )
     corr_fit.add_argument(
-            '--despecklethresh',
-            dest='despeckle_thresh',
-            action='store',
-            type=float,
-            metavar='VAL',
-            help=('Refit correlation if median discontinuity '
-                'magnitude exceeds VAL (default is 5.0s). '),
-            default=5.0)
+        "--despecklethresh",
+        dest="despeckle_thresh",
+        action="store",
+        type=float,
+        metavar="VAL",
+        help=(
+            "Refit correlation if median discontinuity "
+            "magnitude exceeds VAL (default is 5.0s)."
+        ),
+        default=5.0,
+    )
 
     # Regressor refinement options
-    reg_ref = parser.add_argument_group('Regressor refinement options')
-    reg_ref.add_argument('--refineprenorm',
-                         dest='refineprenorm',
-                         action='store',
-                         type=str,
-                         choices=['None', 'mean', 'var', 'std', 'invlag'],
-                         help=("Apply TYPE prenormalization to each "
-                               "timecourse prior to refinement. Default is 'mean'."),
-                         default='mean')
-    reg_ref.add_argument('--refineweighting',
-                         dest='refineweighting',
-                         action='store',
-                         type=str,
-                         choices=['None', 'NIRS', 'R', 'R2'],
-                         help=("Apply TYPE weighting to each timecourse prior "
-                               "to refinement. Default is 'R2'. "),
-                         default='R2')
-    reg_ref.add_argument('--passes',
-                         dest='passes',
-                         action='store',
-                         type=int,
-                         metavar='PASSES',
-                         help=('Set the number of processing passes to '
-                               'PASSES.  Default is 3. '),
-                         default=3)
-    reg_ref.add_argument('--refineinclude',
-                         dest='refineincludespec',
-                         metavar='MASK[:VALSPEC]',
-                         help=('Only use voxels in NAME for regressor refinement '
-                               '(if VALSPEC is given, only voxels '
-                               'with integral values listed in VALSPEC are used). '),
-                         default=None)
-    reg_ref.add_argument('--refineexclude',
-                         dest='refineexcludespec',
-                         metavar='MASK[:VALSPEC]',
-                         help=('Do not use voxels in NAME for regressor refinement '
-                               '(if VALSPEC is given, voxels '
-                               'with integral values listed in VALSPEC are excluded). '),
-                         default=None)
-    reg_ref.add_argument('--lagminthresh',
-                         dest='lagminthresh',
-                         action='store',
-                         metavar='MIN',
-                         type=float,
-                         help=('For refinement, exclude voxels with delays '
-                               'less than MIN (default is 0.25s). '),
-                         default=0.5)
-    reg_ref.add_argument('--lagmaxthresh',
-                         dest='lagmaxthresh',
-                         action='store',
-                         metavar='MAX',
-                         type=float,
-                         help=('For refinement, exclude voxels with delays '
-                               'greater than MAX (default is 5s). '),
-                         default=5.0)
-    reg_ref.add_argument('--ampthresh',
-                         dest='ampthresh',
-                         action='store',
-                         metavar='AMP',
-                         type=float,
-                         help=('For refinement, exclude voxels with correlation '
-                               'coefficients less than AMP (default is 0.3).  NOTE: ampthresh will '
-                               'automatically be set to the p<0.05 significance level determined by '
-                               'the --numnull option if NREPS is set greater than 0 and this is not '
-                               'manually specified.'),
-                         default=-1.0)
-    reg_ref.add_argument('--sigmathresh',
-                         dest='sigmathresh',
-                         action='store',
-                         metavar='SIGMA',
-                         type=float,
-                         help=('For refinement, exclude voxels with widths '
-                               'greater than SIGMA (default is 100s). '),
-                         default=100.0)
-    reg_ref.add_argument('--norefineoffset',
-                         dest='refineoffset',
-                         action='store_false',
-                         help=('Disable realigning refined regressor to zero lag. '),
-                         default=True)
-    reg_ref.add_argument('--psdfilter',
-                         dest='psdfilter',
-                         action='store_true',
-                         help=('Apply a PSD weighted Wiener filter to '
-                               'shifted timecourses prior to refinement. '),
-                         default=False)
-    reg_ref.add_argument('--pickleft',
-                         dest='pickleft',
-                         action='store_true',
-                         help=('Will select the leftmost delay peak when setting the refine offset. '),
-                         default=False)
-    reg_ref.add_argument('--pickleftthresh',
-                         dest='pickleftthresh',
-                         action='store',
-                         metavar='THRESH',
-                         type=float,
-                         help=('Threshhold value (fraction of maximum) in a histogram '
-                               'to be considered the start of a peak.  Default is 0.33.'),
-                         default=0.33)
+    reg_ref = parser.add_argument_group("Regressor refinement options")
+    reg_ref.add_argument(
+        "--refineprenorm",
+        dest="refineprenorm",
+        action="store",
+        type=str,
+        choices=["None", "mean", "var", "std", "invlag"],
+        help=(
+            "Apply TYPE prenormalization to each "
+            "timecourse prior to refinement. Default is 'mean'."
+        ),
+        default="mean",
+    )
+    reg_ref.add_argument(
+        "--refineweighting",
+        dest="refineweighting",
+        action="store",
+        type=str,
+        choices=["None", "NIRS", "R", "R2"],
+        help=(
+            "Apply TYPE weighting to each timecourse prior "
+            "to refinement. Default is 'R2' (r-squared)."
+        ),
+        default="R2",
+    )
+    reg_ref.add_argument(
+        "--passes",
+        dest="passes",
+        action="store",
+        type=int,
+        metavar="PASSES",
+        help=(
+            "Set the number of processing passes to PASSES.  "
+            "Default is 3."),
+        default=3,
+    )
+    reg_ref.add_argument(
+        "--refineinclude",
+        dest="refineincludespec",
+        metavar="MASK[:VALSPEC]",
+        help=(
+            "Only use voxels in file MASK for regressor refinement "
+            "(if VALSPEC is given, only voxels "
+            "with integral values listed in VALSPEC are used). "
+        ),
+        default=None,
+    )
+    reg_ref.add_argument(
+        "--refineexclude",
+        dest="refineexcludespec",
+        metavar="MASK[:VALSPEC]",
+        help=(
+            "Do not use voxels in file MASK for regressor refinement "
+            "(if VALSPEC is given, voxels "
+            "with integral values listed in VALSPEC are excluded). "
+        ),
+        default=None,
+    )
+    reg_ref.add_argument(
+        "--lagminthresh",
+        dest="lagminthresh",
+        action="store",
+        metavar="MIN",
+        type=float,
+        help=(
+            "For refinement, exclude voxels with delays "
+            "less than MIN (default is 0.25s). "
+        ),
+        default=0.5,
+    )
+    reg_ref.add_argument(
+        "--lagmaxthresh",
+        dest="lagmaxthresh",
+        action="store",
+        metavar="MAX",
+        type=float,
+        help=(
+            "For refinement, exclude voxels with delays "
+            "greater than MAX (default is 5s). "
+        ),
+        default=5.0,
+    )
+    reg_ref.add_argument(
+        "--ampthresh",
+        dest="ampthresh",
+        action="store",
+        metavar="AMP",
+        type=float,
+        help=(
+            "For refinement, exclude voxels with correlation "
+            "coefficients less than AMP (default is 0.3).  "
+            "NOTE: ampthresh will automatically be set to the p<0.05 "
+            "significance level determined by the --numnull option if NREPS "
+            "is set greater than 0 and this is not manually specified."
+        ),
+        default=-1.0,
+    )
+    reg_ref.add_argument(
+        "--sigmathresh",
+        dest="sigmathresh",
+        action="store",
+        metavar="SIGMA",
+        type=float,
+        help=(
+            "For refinement, exclude voxels with widths "
+            "greater than SIGMA seconds (default is 100s)."
+        ),
+        default=100.0,
+    )
+    reg_ref.add_argument(
+        "--norefineoffset",
+        dest="refineoffset",
+        action="store_false",
+        help=("Disable realigning refined regressor to zero lag."),
+        default=True,
+    )
+    reg_ref.add_argument(
+        "--psdfilter",
+        dest="psdfilter",
+        action="store_true",
+        help=(
+            "Apply a PSD weighted Wiener filter to "
+            "shifted timecourses prior to refinement."
+        ),
+        default=False,
+    )
+    reg_ref.add_argument(
+        "--pickleft",
+        dest="pickleft",
+        action="store_true",
+        help=(
+            "Will select the leftmost delay peak when setting the refine "
+            "offset."
+        ),
+        default=False,
+    )
+    reg_ref.add_argument(
+        "--pickleftthresh",
+        dest="pickleftthresh",
+        action="store",
+        metavar="THRESH",
+        type=float,
+        help=(
+            "Threshhold value (fraction of maximum) in a histogram "
+            "to be considered the start of a peak.  Default is 0.33."
+        ),
+        default=0.33,
+    )
 
     refine = reg_ref.add_mutually_exclusive_group()
-    refine.add_argument('--refineupperlag',
-                        dest='lagmaskside',
-                        action='store_const',
-                        const='upper',
-                        help=('Only use positive lags for regressor '
-                              'refinement. '),
-                        default='both')
-    refine.add_argument('--refinelowerlag',
-                        dest='lagmaskside',
-                        action='store_const',
-                        const='lower',
-                        help=('Only use negative lags for regressor '
-                              'refinement. '),
-                        default='both')
+    refine.add_argument(
+        "--refineupperlag",
+        dest="lagmaskside",
+        action="store_const",
+        const="upper",
+        help=("Only use positive lags for regressor refinement."),
+        default="both",
+    )
+    refine.add_argument(
+        "--refinelowerlag",
+        dest="lagmaskside",
+        action="store_const",
+        const="lower",
+        help=("Only use negative lags for regressor refinement."),
+        default="both",
+    )
 
-    reg_ref.add_argument('--refinetype',
-                         dest='refinetype',
-                         action='store',
-                         type=str,
-                         choices=['pca', 'ica', 'weighted_average', 'unweighted_average'],
-                         help=('Method with which to derive refined '
-                               'regressor. '),
-                         default='unweighted_average')
+    reg_ref.add_argument(
+        "--refinetype",
+        dest="refinetype",
+        action="store",
+        type=str,
+        choices=["pca", "ica", "weighted_average", "unweighted_average"],
+        help=("Method with which to derive refined regressor."),
+        default="unweighted_average",
+    )
 
     # Output options
-    output = parser.add_argument_group('Output options')
-    output.add_argument('--nolimitoutput',
-                        dest='limitoutput',
-                        action='store_false',
-                        help=("Save some of the large and rarely used "
-                              "files. "),
-                        default=True)
-    output.add_argument('--savelags',
-                        dest='savecorrtimes',
-                        action='store_true',
-                        help='Save a table of lagtimes used. ',
-                        default=False)
-    output.add_argument('--histlen',  # was -h
-                        dest='histlen',
-                        action='store',
-                        type=int,
-                        metavar='HISTLEN',
-                        help=('Change the histogram length to HISTLEN '
-                              '(default is 100). '),
-                        default=100)
-    output.add_argument('--glmsourcefile',
-                        dest='glmsourcefile',
-                        action='store',
-                        type=lambda x: pf.is_valid_file(parser, x),
-                        metavar='FILE',
-                        help=('Regress delayed regressors out of FILE instead '
-                              'of the initial fmri file used to estimate '
-                              'delays. '),
-                        default=None)
-    output.add_argument('--noglm',
-                        dest='doglmfilt',
-                        action='store_false',
-                        help=('Turn off GLM filtering to remove delayed '
-                              'regressor from each voxel (disables output of '
-                              'fitNorm). '),
-                        default=True)
-    output.add_argument('--preservefiltering',
-                        dest='preservefiltering',
-                        action='store_true',
-                        help="Don't reread data prior to performing GLM. ",
-                        default=False)
-    output.add_argument('--saveintermediatemaps',
-                        dest='saveintermediatemaps',
-                        action='store_true',
-                        help='Save lag times, strengths, widths, and mask for each pass. ',
-                        default=False)
-    output.add_argument('--legacyoutput',
-                        dest='bidsoutput',
-                        action='store_false',
-                        help='Use legacy file naming and formats rather than BIDS naming and format conventions for output files. ',
-                        default=True)
+    output = parser.add_argument_group("Output options")
+    output.add_argument(
+        "--nolimitoutput",
+        dest="limitoutput",
+        action="store_false",
+        help=("Save some of the large and rarely used files."),
+        default=True,
+    )
+    output.add_argument(
+        "--savelags",
+        dest="savecorrtimes",
+        action="store_true",
+        help="Save a table of lagtimes used.",
+        default=False,
+    )
+    output.add_argument(
+        "--histlen",  # was -h
+        dest="histlen",
+        action="store",
+        type=int,
+        metavar="HISTLEN",
+        help=("Change the histogram length to HISTLEN (default is 100)."),
+        default=100,
+    )
+    output.add_argument(
+        "--glmsourcefile",
+        dest="glmsourcefile",
+        action="store",
+        type=lambda x: pf.is_valid_file(parser, x),
+        metavar="FILE",
+        help=(
+            "Regress delayed regressors out of FILE instead "
+            "of the initial fmri file used to estimate "
+            "delays."
+        ),
+        default=None,
+    )
+    output.add_argument(
+        "--noglm",
+        dest="doglmfilt",
+        action="store_false",
+        help=(
+            "Turn off GLM filtering to remove delayed "
+            "regressor from each voxel (disables output of "
+            "fitNorm)."
+        ),
+        default=True,
+    )
+    output.add_argument(
+        "--preservefiltering",
+        dest="preservefiltering",
+        action="store_true",
+        help="Don't reread data prior to performing GLM.",
+        default=False,
+    )
+    output.add_argument(
+        "--saveintermediatemaps",
+        dest="saveintermediatemaps",
+        action="store_true",
+        help="Save lag times, strengths, widths, and mask for each pass.",
+        default=False,
+    )
+    output.add_argument(
+        "--legacyoutput",
+        dest="bidsoutput",
+        action="store_false",
+        help=(
+            "Use legacy file naming and formats rather than BIDS naming and "
+            "format conventions for output files."
+        ),
+        default=True,
+    )
 
     # Miscellaneous options
-    misc = parser.add_argument_group('Miscellaneous options')
-    misc.add_argument('--noprogressbar',
-                      dest='showprogressbar',
-                      action='store_false',
-                      help='Will disable showing progress bars (helpful if stdout is going to a file). ',
-                      default=True)
-    misc.add_argument('--checkpoint',
-                      dest='checkpoint',
-                      action='store_true',
-                      help='Enable run checkpoints. ',
-                      default=False)
-    misc.add_argument('--wiener',
-                      dest='dodeconv',
-                      action='store_true',
-                      help=('Do Wiener deconvolution to find voxel transfer '
-                            'function. '),
-                      default=False)
-    misc.add_argument('--spcalculation',
-                      dest='internalprecision',
-                      action='store_const',
-                      const='single',
-                      help=('Use single precision for internal calculations '
-                            '(may be useful when RAM is limited). '),
-                      default='double')
-    misc.add_argument('--dpoutput',
-                      dest='outputprecision',
-                      action='store_const',
-                      const='double',
-                      help=('Use double precision for output files. '),
-                      default='single')
-    misc.add_argument('--cifti',
-                      dest='isgrayordinate',
-                      action='store_true',
-                      help='Data file is a converted CIFTI. ',
-                      default=False)
-    misc.add_argument('--simulate',
-                      dest='fakerun',
-                      action='store_true',
-                      help='Simulate a run - just report command line options. ',
-                      default=False)
-    misc.add_argument('--displayplots',
-                      dest='displayplots',
-                      action='store_true',
-                      help='Display plots of interesting timecourses. ',
-                      default=False)
-    misc.add_argument('--nonumba',
-                      dest='nonumba',
-                      action='store_true',
-                      help='Disable jit compilation with numba. ',
-                      default=False)
-    misc.add_argument('--nosharedmem',
-                      dest='sharedmem',
-                      action='store_false',
-                      help=('Disable use of shared memory for large array '
-                            'storage. '),
-                      default=True)
-    misc.add_argument('--memprofile',
-                      dest='memprofile',
-                      action='store_true',
-                      help=('Enable memory profiling for debugging - '
-                            'warning: this slows things down a lot. '),
-                      default=False)
-    misc.add_argument('--mklthreads',
-                      dest='mklthreads',
-                      action='store',
-                      type=int,
-                      metavar='MKLTHREADS',
-                      help=('Use no more than MKLTHREADS worker threads in accelerated numpy calls. '),
-                      default=1)
-    misc.add_argument('--nprocs',
-                      dest='nprocs',
-                      action='store',
-                      type=int,
-                      metavar='NPROCS',
-                      help=('Use NPROCS worker processes for multiprocessing. '
-                            'Setting NPROCS to less than 1 sets the number of '
-                            'worker processes to n_cpus - 1. '),
-                      default=1)
-    misc.add_argument('--debug',
-                      dest='debug',
-                      action='store_true',
-                      help=('Enable additional debugging output.'),
-                      default=False)
-    misc.add_argument('--verbose',
-                      dest='verbose',
-                      action='store_true',
-                      help=('Enable additional runtime information output. '),
-                      default=False)
+    misc = parser.add_argument_group("Miscellaneous options")
+    misc.add_argument(
+        "--noprogressbar",
+        dest="showprogressbar",
+        action="store_false",
+        help=(
+            "Will disable showing progress bars (helpful if stdout is going "
+            "to a file)."
+        ),
+        default=True,
+    )
+    misc.add_argument(
+        "--checkpoint",
+        dest="checkpoint",
+        action="store_true",
+        help="Enable run checkpoints.",
+        default=False,
+    )
+    misc.add_argument(
+        "--wiener",
+        dest="dodeconv",
+        action="store_true",
+        help=("Do Wiener deconvolution to find voxel transfer function."),
+        default=False,
+    )
+    misc.add_argument(
+        "--spcalculation",
+        dest="internalprecision",
+        action="store_const",
+        const="single",
+        help=(
+            "Use single precision for internal calculations "
+            "(may be useful when RAM is limited)."
+        ),
+        default="double",
+    )
+    misc.add_argument(
+        "--dpoutput",
+        dest="outputprecision",
+        action="store_const",
+        const="double",
+        help=("Use double precision for output files."),
+        default="single",
+    )
+    misc.add_argument(
+        "--cifti",
+        dest="isgrayordinate",
+        action="store_true",
+        help="Data file is a converted CIFTI.",
+        default=False,
+    )
+    misc.add_argument(
+        "--simulate",
+        dest="fakerun",
+        action="store_true",
+        help="Simulate a run - just report command line options.",
+        default=False,
+    )
+    misc.add_argument(
+        "--displayplots",
+        dest="displayplots",
+        action="store_true",
+        help="Display plots of interesting timecourses.",
+        default=False,
+    )
+    misc.add_argument(
+        "--nonumba",
+        dest="nonumba",
+        action="store_true",
+        help="Disable jit compilation with numba.",
+        default=False,
+    )
+    misc.add_argument(
+        "--nosharedmem",
+        dest="sharedmem",
+        action="store_false",
+        help=("Disable use of shared memory for large array storage."),
+        default=True,
+    )
+    misc.add_argument(
+        "--memprofile",
+        dest="memprofile",
+        action="store_true",
+        help=(
+            "Enable memory profiling for debugging - "
+            "warning: this slows things down a lot."
+        ),
+        default=False,
+    )
+    misc.add_argument(
+        "--mklthreads",
+        dest="mklthreads",
+        action="store",
+        type=int,
+        metavar="MKLTHREADS",
+        help=(
+            "Use no more than MKLTHREADS worker threads in accelerated numpy "
+            "calls."
+        ),
+        default=1,
+    )
+    misc.add_argument(
+        "--nprocs",
+        dest="nprocs",
+        action="store",
+        type=int,
+        metavar="NPROCS",
+        help=(
+            "Use NPROCS worker processes for multiprocessing. "
+            "Setting NPROCS to less than 1 sets the number of "
+            "worker processes to n_cpus - 1."
+        ),
+        default=1,
+    )
+    misc.add_argument(
+        "--debug",
+        dest="debug",
+        action="store_true",
+        help=("Enable additional debugging output."),
+        default=False,
+    )
+    misc.add_argument(
+        "--verbose",
+        dest="verbose",
+        action="store_true",
+        help=("Enable additional runtime information output."),
+        default=False,
+    )
 
     # Experimental options (not fully tested, may not work)
-    experimental = parser.add_argument_group('Experimental options (not fully '
-                                             'tested, may not work)')
-    experimental.add_argument('--respdelete',
-                              dest='respdelete',
-                              action='store_true',
-                              help=('Attempt to detect and remove respiratory signal that strays into the LFO band.'),
-                              default=False)
-    experimental.add_argument('--correlatorhpfreq',
-                              dest='correlator_hpfreq',
-                              action='store',
-                              metavar='HPFREQ',
-                              type=float,
-                              help=('High pass filter the correlation function to get rid of baseline problems. '),
-                              default=None)
-    experimental.add_argument('--cleanrefined',
-                              dest='cleanrefined',
-                              action='store_true',
-                              help=('Perform additional processing on refined '
-                                    'regressor to remove spurious '
-                                    'components. '),
-                              default=False)
-    experimental.add_argument('--dispersioncalc',
-                              dest='dodispersioncalc',
-                              action='store_true',
-                              help=('Generate extra data during refinement to '
-                                    'allow calculation of dispersion. '),
-                              default=False)
-    experimental.add_argument('--acfix',
-                              dest='fix_autocorrelation',
-                              action='store_true',
-                              help=('Perform a secondary correlation to '
-                                    'disambiguate peak location. Experimental. '),
-                              default=False)
-    experimental.add_argument('--alwaysmultiproc',
-                              dest='alwaysmultiproc',
-                              action='store_true',
-                              help=('Use the multiprocessing code path even when nprocs=1. '),
-                              default=False)
-    experimental.add_argument('--tmask',
-                              dest='tmaskname',
-                              action='store',
-                              type=lambda x: pf.is_valid_file(parser, x),
-                              metavar='FILE',
-                              help=('Only correlate during epochs specified '
-                                    'in MASKFILE (NB: each line of FILE '
-                                    'contains the time and duration of an '
-                                    'epoch to include. '),
-                              default=None)
+    experimental = parser.add_argument_group(
+        "Experimental options (not fully tested, may not work)"
+    )
+    experimental.add_argument(
+        "--respdelete",
+        dest="respdelete",
+        action="store_true",
+        help=(
+            "Attempt to detect and remove respiratory signal that strays into "
+            "the LFO band."
+        ),
+        default=False,
+    )
+    experimental.add_argument(
+        "--correlatorhpfreq",
+        dest="correlator_hpfreq",
+        action="store",
+        metavar="HPFREQ",
+        type=float,
+        help=(
+            "High pass filter the correlation function to get rid of baseline "
+            "problems."
+        ),
+        default=None,
+    )
+    experimental.add_argument(
+        "--cleanrefined",
+        dest="cleanrefined",
+        action="store_true",
+        help=(
+            "Perform additional processing on refined "
+            "regressor to remove spurious "
+            "components."
+        ),
+        default=False,
+    )
+    experimental.add_argument(
+        "--dispersioncalc",
+        dest="dodispersioncalc",
+        action="store_true",
+        help=(
+            "Generate extra data during refinement to "
+            "allow calculation of dispersion."
+        ),
+        default=False,
+    )
+    experimental.add_argument(
+        "--acfix",
+        dest="fix_autocorrelation",
+        action="store_true",
+        help=(
+            "Perform a secondary correlation to "
+            "disambiguate peak location. Experimental."
+        ),
+        default=False,
+    )
+    experimental.add_argument(
+        "--alwaysmultiproc",
+        dest="alwaysmultiproc",
+        action="store_true",
+        help=("Use the multiprocessing code path even when nprocs=1."),
+        default=False,
+    )
+    experimental.add_argument(
+        "--tmask",
+        dest="tmaskname",
+        action="store",
+        type=lambda x: pf.is_valid_file(parser, x),
+        metavar="FILE",
+        help=(
+            "Only correlate during epochs specified "
+            "in MASKFILE (NB: each line of FILE "
+            "contains the time and duration of an "
+            "epoch to include."
+        ),
+        default=None,
+    )
 
     # Debugging options
-    debugging = parser.add_argument_group('Debugging options (not for general use)')
-    experimental.add_argument('--singleproc_getNullDist',
-                              dest='singleproc_getNullDist',
-                              action='store_true',
-                              help=('Force single proc path for getNullDist.'),
-                              default=False)
-    experimental.add_argument('--singleproc_calcsimilarity',
-                              dest='singleproc_calcsimilarity',
-                              action='store_true',
-                              help=('Force single proc path for calcsimilarity.'),
-                              default=False)
-    experimental.add_argument('--singleproc_peakeval',
-                              dest='singleproc_peakeval',
-                              action='store_true',
-                              help=('Force single proc path for peakeval.'),
-                              default=False)
-    experimental.add_argument('--singleproc_fitcorr',
-                              dest='singleproc_fitcorr',
-                              action='store_true',
-                              help=('Force single proc path for fitcorr.'),
-                              default=False)
-    experimental.add_argument('--singleproc_glm',
-                              dest='singleproc_glm',
-                              action='store_true',
-                              help=('Force single proc path for glm.'),
-                              default=False)
+    debugging = parser.add_argument_group("Debugging options")
+    debugging.add_argument(
+        "--singleproc_getNullDist",
+        dest="singleproc_getNullDist",
+        action="store_true",
+        help=("Force single proc path for getNullDist."),
+        default=False,
+    )
+    debugging.add_argument(
+        "--singleproc_calcsimilarity",
+        dest="singleproc_calcsimilarity",
+        action="store_true",
+        help=("Force single proc path for calcsimilarity."),
+        default=False,
+    )
+    debugging.add_argument(
+        "--singleproc_peakeval",
+        dest="singleproc_peakeval",
+        action="store_true",
+        help=("Force single proc path for peakeval."),
+        default=False,
+    )
+    debugging.add_argument(
+        "--singleproc_fitcorr",
+        dest="singleproc_fitcorr",
+        action="store_true",
+        help=("Force single proc path for fitcorr."),
+        default=False,
+    )
+    debugging.add_argument(
+        "--singleproc_glm",
+        dest="singleproc_glm",
+        action="store_true",
+        help=("Force single proc path for glm."),
+        default=False,
+    )
 
     return parser
 
@@ -899,7 +1193,7 @@ def process_args(inputargs=None):
     Compile arguments for rapidtide workflow.
     """
     if inputargs is None:
-        print('processing command line arguments')
+        LGR.info("processing command line arguments")
         # write out the command used
         try:
             args = vars(_get_parser().parse_args())
@@ -908,8 +1202,8 @@ def process_args(inputargs=None):
             _get_parser().print_help()
             raise
     else:
-        print('processing passed argument list:')
-        print(inputargs)
+        LGR.info("processing passed argument list:")
+        LGR.info(inputargs)
         try:
             args = vars(_get_parser().parse_args(inputargs))
             argstowrite = inputargs
@@ -917,270 +1211,332 @@ def process_args(inputargs=None):
             _get_parser().print_help()
             raise
 
+    sh = logging.StreamHandler()
+    if args["debug"]:
+        logging.basicConfig(level=logging.DEBUG,
+                            handlers=[sh])
+    else:
+        logging.basicConfig(level=logging.INFO,
+                            handlers=[sh])
+
     # save the raw and formatted command lines
-    args['commandlineargs'] = argstowrite[1:]
-    thecommandline = ' '.join(argstowrite)
-    tide_io.writevec([thecommandline], args['outputname'] + '_commandline.txt')
+    args["commandlineargs"] = argstowrite[1:]
+    thecommandline = " ".join(argstowrite)
+    tide_io.writevec([thecommandline], args["outputname"] + "_commandline.txt")
     formattedcommandline = []
     for thetoken in argstowrite[0:3]:
         formattedcommandline.append(thetoken)
     for thetoken in argstowrite[3:]:
-        if thetoken[0:2] == '--':
+        if thetoken[0:2] == "--":
             formattedcommandline.append(thetoken)
         else:
-            formattedcommandline[-1] += ' ' + thetoken
+            formattedcommandline[-1] += " " + thetoken
     for i in range(len(formattedcommandline)):
         if i > 0:
-            prefix = '    '
+            prefix = "    "
         else:
-            prefix = ''
+            prefix = ""
         if i < len(formattedcommandline) - 1:
-            suffix = ' \\'
+            suffix = " \\"
         else:
-            suffix = ''
+            suffix = ""
         formattedcommandline[i] = prefix + formattedcommandline[i] + suffix
-    tide_io.writevec(formattedcommandline, args['outputname'] + '_formattedcommandline.txt')
+    tide_io.writevec(
+        formattedcommandline, args["outputname"] + "_formattedcommandline.txt"
+    )
 
-    if args['debug']:
-        print()
-        print('before postprocessing')
-        print(args)
+    LGR.debug("\nbefore postprocessing:\n{}".format(args))
 
     # some tunable parameters for internal debugging
-    args['dodemean'] = True
-    args['edgebufferfrac'] = 0.0  # what fraction of the correlation window to avoid on either end when fitting
-    args['enforcethresh'] = True  # only do fits in voxels that exceed threshhold
-    args['lagmod'] = 1000.0  # if set to the location of the first autocorrelation sidelobe, this will fold back sidelobes
-    args['lthreshval'] = 0.0  # zero out peaks with correlations lower than this value
-    args['uthreshval'] = 1.0  # zero out peaks with correlations higher than this value
-    args['absmaxsigma'] = 10000.0  # width of the reference autocorrelation function
-    args['absminsigma'] = 0.25  # width of the reference autocorrelation function
+    args["dodemean"] = True
+    # what fraction of the correlation window to avoid on either end when
+    # fitting
+    args["edgebufferfrac"] = 0.0
+    # only do fits in voxels that exceed threshhold
+    args["enforcethresh"] = True
+    # if set to the location of the first autocorrelation sidelobe,
+    # this will fold back sidelobes
+    args["lagmod"] = 1000.0
+    # zero out peaks with correlations lower than this value
+    args["lthreshval"] = 0.0
+    # zero out peaks with correlations higher than this value
+    args["uthreshval"] = 1.0
+    # width of the reference autocorrelation function
+    args["absmaxsigma"] = 10000.0
+    # width of the reference autocorrelation function
+    args["absminsigma"] = 0.25
 
     # correlation fitting
-    args['hardlimit'] = True  # Peak value must be within specified range.  If false, allow max outside if maximum
-                              # correlation value is that one end of the range.
-    args['searchfrac'] = 0.5  # The fraction of the main peak over which points are included in the peak
-    args['mp_chunksize'] = 50000
+    # Peak value must be within specified range.
+    # If false, allow max outside if maximum
+    # correlation value is that one end of the range.
+    args["hardlimit"] = True
+    # The fraction of the main peak over which points are included in the peak
+    args["searchfrac"] = 0.5
+    args["mp_chunksize"] = 50000
 
     # significance estimation
-    args['sighistlen'] = 1000
-    args['dosighistfit'] = True
+    args["sighistlen"] = 1000
+    args["dosighistfit"] = True
 
     # output options
-    args['savecorrmask'] = True
-    args['savedespecklemasks'] = True
-    args['saveglmfiltered'] = True
-    args['savemotionfiltered'] = False
-    args['savecorrmask'] = True
-    args['histlen'] = 250
+    args["savecorrmask"] = True
+    args["savedespecklemasks"] = True
+    args["saveglmfiltered"] = True
+    args["savemotionfiltered"] = False
+    args["savecorrmask"] = True
+    args["histlen"] = 250
 
     # refinement options
-    args['estimatePCAdims'] = False
-    args['filterbeforePCA'] = True
-    args['dispersioncalc_step'] = 0.50
+    args["estimatePCAdims"] = False
+    args["filterbeforePCA"] = True
+    args["dispersioncalc_step"] = 0.50
 
     # autocorrelation processing
-    args['check_autocorrelation'] = True
-    args['acwidth'] = 0.0  # width of the reference autocorrelation function
+    args["check_autocorrelation"] = True
+    args["acwidth"] = 0.0  # width of the reference autocorrelation function
 
     # diagnostic information about version
-    args['release_version'], args['git_longtag'], args['git_date'], args['git_isdirty'] = tide_util.version()
-    args['python_version'] = str(sys.version_info)
-
+    (
+        args["release_version"],
+        args["git_longtag"],
+        args["git_date"],
+        args["git_isdirty"],
+    ) = tide_util.version()
+    args["python_version"] = str(sys.version_info)
 
     # configure the filter
     # if arbvec is set, we are going set up an arbpass filter
-    if args['arbvec'] is not None:
-        if len(args['arbvec']) == 2:
-            args['arbvec'].append(args['arbvec'][0] * 0.95)
-            args['arbvec'].append(args['arbvec'][1] * 1.05)
-        elif len(args['arbvec']) != 4:
-            raise ValueError("Argument '--arb' must be either two "
-                             "or four floats.")
+    if args["arbvec"] is not None:
+        if len(args["arbvec"]) == 2:
+            args["arbvec"].append(args["arbvec"][0] * 0.95)
+            args["arbvec"].append(args["arbvec"][1] * 1.05)
+        elif len(args["arbvec"]) != 4:
+            raise ValueError("Argument '--arb' must be either two or four "
+                             "floats.")
         # NOTE - this vector is LOWERPASS, UPPERPASS, LOWERSTOP, UPPERSTOP
         # setfreqs expects LOWERSTOP, LOWERPASS, UPPERPASS, UPPERSTOP
-        theprefilter = tide_filt.noncausalfilter('arb',
-                                                 transferfunc=args['filtertype'],
-                                                 debug=args['debug'])
-        theprefilter.setfreqs(args['arbvec'][2], args['arbvec'][0], args['arbvec'][1], args['arbvec'][3])
+        theprefilter = tide_filt.noncausalfilter(
+            "arb", transferfunc=args["filtertype"], debug=args["debug"]
+        )
+        theprefilter.setfreqs(
+            args["arbvec"][2],
+            args["arbvec"][0],
+            args["arbvec"][1],
+            args["arbvec"][3],
+        )
     else:
-        theprefilter = tide_filt.noncausalfilter(args['filterband'],
-                                                 transferfunc=args['filtertype'],
-                                                 debug=args['debug'])
+        theprefilter = tide_filt.noncausalfilter(
+            args["filterband"],
+            transferfunc=args["filtertype"],
+            debug=args["debug"],
+        )
 
-    theprefilter.setbutterorder(args['filtorder'])
-    args['lowerstop'], args['lowerpass'], args['upperpass'], args['upperstop'] = theprefilter.getfreqs()
-
+    theprefilter.setbutterorder(args["filtorder"])
+    (
+        args["lowerstop"],
+        args["lowerpass"],
+        args["upperpass"],
+        args["upperstop"],
+    ) = theprefilter.getfreqs()
 
     # Additional argument parsing not handled by argparse
-    args['despeckle_passes'] = np.max([args['despeckle_passes'], 0])
+    args["despeckle_passes"] = np.max([args["despeckle_passes"], 0])
 
-    try:
-        test = args['lag_extrema_nondefault']
-        args['lagmin_nondefault'] = True
-        args['lagmax_nondefault'] = True
-    except KeyError:
-        pass
-    args['lagmin'] = args['lag_extrema'][0]
-    args['lagmax'] = args['lag_extrema'][1]
-    args['startpoint'] = args['timerange'][0]
-    if args['timerange'][1] == -1:
-        args['endpoint'] = 100000000
+    if "lag_extrema_nondefault" in args.keys():
+        args["lagmin_nondefault"] = True
+        args["lagmax_nondefault"] = True
+
+    args["lagmin"] = args["lag_extrema"][0]
+    args["lagmax"] = args["lag_extrema"][1]
+    args["startpoint"] = args["timerange"][0]
+    if args["timerange"][1] == -1:
+        args["endpoint"] = 100000000
     else:
-        args['endpoint'] = args['timerange'][1]
+        args["endpoint"] = args["timerange"][1]
 
-    args['offsettime_total'] = args['offsettime'] + 0.0
+    args["offsettime_total"] = args["offsettime"] + 0.0
 
-    reg_ref_used = ((args['lagminthresh'] != 0.5) or
-                    (args['lagmaxthresh'] != 5.) or
-                    (args['ampthresh'] != 0.3) or
-                    (args['sigmathresh'] != 100.) or
-                    (args['refineoffset']))
-    if reg_ref_used and args['passes'] == 1:
-        print('WARNING: One or more arguments have been set that are only relevant if performing refinement.  If you want to do refinement, set passes > 1.')
+    reg_ref_used = (
+        (args["lagminthresh"] != 0.5)
+        or (args["lagmaxthresh"] != 5.0)
+        or (args["ampthresh"] != 0.3)
+        or (args["sigmathresh"] != 100.0)
+        or (args["refineoffset"])
+    )
+    if reg_ref_used and args["passes"] == 1:
+        LGR.warning(
+            "One or more arguments have been set that are only "
+            "relevant if performing refinement.  "
+            "If you want to do refinement, set passes > 1."
+        )
 
-    if args['numestreps'] == 0:
-        args['ampthreshfromsig'] = False
+    if args["numestreps"] == 0:
+        args["ampthreshfromsig"] = False
     else:
-        args['ampthreshfromsig'] = True
+        args["ampthreshfromsig"] = True
 
-    if args['ampthresh'] < 0.0:
-        args['ampthresh'] = 0.3
-        args['ampthreshfromsig'] = True
+    if args["ampthresh"] < 0.0:
+        args["ampthresh"] = 0.3
+        args["ampthreshfromsig"] = True
     else:
-        args['ampthreshfromsig'] = False
+        args["ampthreshfromsig"] = False
 
-    if args['despeckle_thresh'] != 5.0 and args['despeckle_passes'] == 0:
-        args['despeckle_passes'] = 1
+    if args["despeckle_thresh"] != 5.0 and args["despeckle_passes"] == 0:
+        args["despeckle_passes"] = 1
 
-    if args['zerooutbadfit']:
-        args['nohistzero'] = False
+    if args["zerooutbadfit"]:
+        args["nohistzero"] = False
     else:
-        args['nohistzero'] = True
+        args["nohistzero"] = True
 
-    if args['fixeddelayvalue'] is not None:
-        args['fixdelay'] = True
-        args['lag_extrema'] = (args['fixeddelayvalue'] - 10.0,
-                               args['fixeddelayvalue'] + 10.0)
+    if args["fixeddelayvalue"] is not None:
+        args["fixdelay"] = True
+        args["lag_extrema"] = (
+            args["fixeddelayvalue"] - 10.0,
+            args["fixeddelayvalue"] + 10.0,
+        )
     else:
-        args['fixdelay'] = False
+        args["fixdelay"] = False
 
-    if args['in_file'].endswith('txt') and args['realtr'] == 'auto':
-        raise ValueError('Either --datatstep or --datafreq must be provided '
-                         'if data file is a text file.')
+    if args["in_file"].endswith("txt") and args["realtr"] == "auto":
+        raise ValueError(
+            "Either --datatstep or --datafreq must be provided "
+            "if data file is a text file."
+        )
 
-    if args['realtr'] != 'auto':
-        fmri_tr = float(args['realtr'])
+    if args["realtr"] != "auto":
+        fmri_tr = float(args["realtr"])
     else:
-        fmri_tr = nib.load(args['in_file']).header.get_zooms()[3]
-    args['realtr'] = fmri_tr
+        fmri_tr = nib.load(args["in_file"]).header.get_zooms()[3]
+    args["realtr"] = fmri_tr
 
-    if args['inputfreq'] == 'auto':
-        args['inputfreq'] = 1. / fmri_tr
+    if args["inputfreq"] == "auto":
+        args["inputfreq"] = 1.0 / fmri_tr
 
     # mask processing
-    if args['corrmaskincludespec'] is not None:
-        args['corrmaskincludename'], args['corrmaskincludevals'] = tide_io.processnamespec(args['corrmaskincludespec'],
-                                                                                           'Including voxels where ',
-                                                                                           'in correlation calculations.')
+    if args["corrmaskincludespec"] is not None:
+        (
+            args["corrmaskincludename"],
+            args["corrmaskincludevals"],
+        ) = tide_io.processnamespec(
+            args["corrmaskincludespec"],
+            "Including voxels where ",
+            "in correlation calculations.",
+        )
     else:
-        args['corrmaskincludename'] = None
+        args["corrmaskincludename"] = None
 
-    if args['globalmeanincludespec'] is not None:
-        args['globalmeanincludename'], args['globalmeanincludevals'] = tide_io.processnamespec(args['globalmeanincludespec'],
-                                                                                               'Including voxels where ',
-                                                                                               'in global mean.')
+    if args["globalmeanincludespec"] is not None:
+        (args["globalmeanincludename"],
+         args["globalmeanincludevals"]) = tide_io.processnamespec(
+            args["globalmeanincludespec"],
+            "Including voxels where ",
+            "in global mean."
+        )
     else:
-        args['globalmeanincludename'] = None
+        args["globalmeanincludename"] = None
 
-    if args['globalmeanexcludespec'] is not None:
-        args['globalmeanexcludename'], args['globalmeanexcludevals'] = tide_io.processnamespec(args['globalmeanexcludespec'],
-                                                                                               'Excluding voxels where ',
-                                                                                               'from global mean.')
+    if args["globalmeanexcludespec"] is not None:
+        (
+            args["globalmeanexcludename"],
+            args["globalmeanexcludevals"],
+        ) = tide_io.processnamespec(
+            args["globalmeanexcludespec"],
+            "Excluding voxels where ",
+            "from global mean.",
+        )
     else:
-        args['globalmeanexcludename'] = None
+        args["globalmeanexcludename"] = None
 
-    if args['refineincludespec'] is not None:
-        args['refineincludename'], args['refineincludevals'] = tide_io.processnamespec(args['refineincludespec'],
-                                                                                       'Including voxels where ',
-                                                                                       'in refinement.')
+    if args["refineincludespec"] is not None:
+        (args["refineincludename"],
+         args["refineincludevals"]) = tide_io.processnamespec(
+            args["refineincludespec"],
+            "Including voxels where ",
+            "in refinement."
+        )
     else:
-        args['refineincludename'] = None
+        args["refineincludename"] = None
 
-    if args['refineexcludespec'] is not None:
-        args['refineexcludename'], args['refineexcludevals'] = tide_io.processnamespec(args['refineexcludespec'],
-                                                                                       'Excluding voxels where ',
-                                                                                       'from refinement.')
+    if args["refineexcludespec"] is not None:
+        (args["refineexcludename"],
+         args["refineexcludevals"]) = tide_io.processnamespec(
+            args["refineexcludespec"],
+            "Excluding voxels where ",
+            "from refinement."
+        )
     else:
-        args['refineexcludename'] = None
+        args["refineexcludename"] = None
 
     # motion processing
-    if args['motionfilespec'] is not None:
-        args['motionfilename'], args['motionfilevals'] = tide_io.processnamespec(args['motionfilespec'],
-                                                                         'Using columns in ',
-                                                                         'as motion regressors.')
+    if args["motionfilespec"] is not None:
+        (args["motionfilename"],
+         args["motionfilevals"]) = tide_io.processnamespec(
+            args["motionfilespec"],
+            "Using columns in ",
+            "as motion regressors."
+        )
     else:
-        args['motionfilename'] = None
+        args["motionfilename"] = None
 
-    if args['venousrefine']:
-        print('WARNING: Using "venousrefine" macro. Overriding any affected '
-              'arguments.')
-        args['lagminthresh'] = 2.5
-        args['lagmaxthresh'] = 6.
-        args['ampthresh'] = 0.5
-        args['ampthreshfromsig'] = False
-        args['lagmaskside'] = 'upper'
+    if args["venousrefine"]:
+        LGR.warning(
+            "Using 'venousrefine' macro. Overriding any affected arguments."
+        )
+        args["lagminthresh"] = 2.5
+        args["lagmaxthresh"] = 6.0
+        args["ampthresh"] = 0.5
+        args["ampthreshfromsig"] = False
+        args["lagmaskside"] = "upper"
 
-    if args['nirs']:
-        print('WARNING: Using "nirs" macro. Overriding any affected '
-              'arguments.')
-        args['nothresh'] = False
-        args['preservefiltering'] = True
-        args['refineprenorm'] = 'var'
-        args['ampthresh'] = 0.7
-        args['ampthreshfromsig'] = False
-        args['lagmaskthresh'] = 0.1
+    if args["nirs"]:
+        LGR.warning("Using 'nirs' macro. Overriding any affected arguments.")
+        args["nothresh"] = False
+        args["preservefiltering"] = True
+        args["refineprenorm"] = "var"
+        args["ampthresh"] = 0.7
+        args["ampthreshfromsig"] = False
+        args["lagmaskthresh"] = 0.1
 
-    if args['delaymapping']:
-        pf.setifnotset(args, 'despeckle_passes', 4)
-        pf.setifnotset(args, 'lagmin', -10.0)
-        pf.setifnotset(args, 'lagmax', 30.0)
-        args['passes'] = 3
-        args['refineoffset'] = True
-        args['pickleft'] = True
-        args['limitoutput'] = True
-        pf.setifnotset(args, 'doglmfilt', False)
+    if args["delaymapping"]:
+        pf.setifnotset(args, "despeckle_passes", 4)
+        pf.setifnotset(args, "lagmin", -10.0)
+        pf.setifnotset(args, "lagmax", 30.0)
+        args["passes"] = 3
+        args["refineoffset"] = True
+        args["pickleft"] = True
+        args["limitoutput"] = True
+        pf.setifnotset(args, "doglmfilt", False)
 
-    if args['denoising']:
-        pf.setifnotset(args, 'despeckle_passes', 4)
-        pf.setifnotset(args, 'lagmin', -10.0)
-        pf.setifnotset(args, 'lagmax', 10.0)
-        pf.setifnotset(args, 'peakfittype', 'gauss')
-        args['passes'] = 3
-        args['refineoffset'] = True
-        args['doglmfilt'] = True
-
+    if args["denoising"]:
+        pf.setifnotset(args, "despeckle_passes", 4)
+        pf.setifnotset(args, "lagmin", -10.0)
+        pf.setifnotset(args, "lagmax", 10.0)
+        pf.setifnotset(args, "peakfittype", "gauss")
+        args["passes"] = 3
+        args["refineoffset"] = True
+        args["doglmfilt"] = True
 
     # process limitoutput
-    if args['limitoutput']:
-        args['savemovingsignal'] = False
-        args['savelagregressors'] = False
+    if args["limitoutput"]:
+        args["savemovingsignal"] = False
+        args["savelagregressors"] = False
     else:
-        args['savemovingsignal'] = True
-        args['savelagregressors'] = True
-
+        args["savemovingsignal"] = True
+        args["savelagregressors"] = True
 
     # dispersion calculation
-    args['dispersioncalc_lower'] = args['lagmin']
-    args['dispersioncalc_upper'] = args['lagmax']
-    args['dispersioncalc_step'] = np.max(
-        [(args['dispersioncalc_upper'] - args['dispersioncalc_lower']) / 25,
-         args['dispersioncalc_step']])
+    args["dispersioncalc_lower"] = args["lagmin"]
+    args["dispersioncalc_upper"] = args["lagmax"]
+    args["dispersioncalc_step"] = np.max(
+        [
+            (args["dispersioncalc_upper"] - args["dispersioncalc_lower"]) / 25,
+            args["dispersioncalc_step"],
+        ]
+    )
 
-    if args['debug']:
-        print()
-        print('after postprocessing')
-        print(args)
+    LGR.debug("\nafter postprocessing\n{}".format(args))
 
     # start the clock!
     tide_util.checkimports(args)


### PR DESCRIPTION
<!---
This is a suggested pull request template for rapidtide.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
http://rapidtide.readthedocs.io/en/latest/contributing.html#pull-requests
-->

Closes None. I should have opened an issue about this before opening this PR, but I wanted exhibit some changes I was hoping to make to the package with a test case (the rapidtide parser).

Changes proposed in this pull request:

- Run `black` on `workflows/rapidtide_parser.py` and `workflows/parser_funcs.py`. This standardizes the style a bit and should help with PEP8-related issues. Plus, it has the added benefit of minimizing future diffs, which will make it easier to review changes.
- Switch from printing messages to logging them in `workflows/rapidtide_parser.py` (related to #41).
- Add some argument group-level descriptions (in addition to the titles) in `workflows/rapidtide_parser.py`.
- Adopt UpperCamelCase for a class in `workflows/parser_funcs.py`, to match PEP8 convention.
- Adopt CAPITALCASE for constants in `workflows/parser_funcs.py`, to match PEP8 convention.
- Clean up a few heading levels in `docs/usage.rst`, and add a comment that documents the levels for easy reference (I kept confusing myself).
- Use code formatting in a couple of places in `docs/usage.rst`, which might make referencing arguments a little easier.
- Hide debugging-related arguments in the argparse-generated documentation in `docs/usage.rst`. I didn't actually know about this feature before now, and it's pretty cool!
