### PR TITLE
[FIX, TST] Drop caching from 3.6 and 3.8 tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           name: Run Py3.6 tests
           command: |
             source activate py36_env
-            py.test rapidtide
+            py.test rapidtide --ignore=candidatetests
 
   test_py38:
     working_directory: /tmp/src/rapidtide
@@ -61,7 +61,7 @@ jobs:
           name: Run Py3.8 tests
           command: |
             source activate py38_env
-            py.test rapidtide
+            py.test rapidtide --ignore=candidatetests
 
   make_env_py37:
     working_directory: /tmp/src/rapidtide
@@ -141,7 +141,7 @@ jobs:
           command:  |
             apt-get install -yqq curl
             source activate py37_env
-            py.test --cov-report xml:coverage.xml --cov=rapidtide rapidtide
+            py.test --ignore=candidatetests --cov-report xml:coverage.xml --cov=rapidtide rapidtide
       - codecov/upload:
           file: /tmp/src/rapidtide/coverage.xml
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           name: Run Py3.6 tests
           command: |
             source activate py36_env
-            py.test rapidtide --ignore=candidatetests
+            py.test rapidtide --ignore=rapidtide/candidatetests
 
   test_py38:
     working_directory: /tmp/src/rapidtide
@@ -61,7 +61,7 @@ jobs:
           name: Run Py3.8 tests
           command: |
             source activate py38_env
-            py.test rapidtide --ignore=candidatetests
+            py.test rapidtide --ignore=rapidtide/candidatetests
 
   make_env_py37:
     working_directory: /tmp/src/rapidtide
@@ -141,7 +141,7 @@ jobs:
           command:  |
             apt-get install -yqq curl
             source activate py37_env
-            py.test --ignore=candidatetests --cov-report xml:coverage.xml --cov=rapidtide rapidtide
+            py.test --ignore=rapidtide/candidatetests --cov-report xml:coverage.xml --cov=rapidtide rapidtide
       - codecov/upload:
           file: /tmp/src/rapidtide/coverage.xml
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,6 @@ jobs:
           root: /tmp
           paths:
               - src/rapidtide
-      - restore_cache:  # ensure this step occurs *before* installing dependencies
-          key: deps9-{{ checksum "setup.py" }}
       - run:  # will overwrite rapidtide installation each time
           name: Generate environment
           command:  |
@@ -31,17 +29,41 @@ jobs:
                 pip install -e .[tests,doc]
             fi
             python setup.py install --user
-      - save_cache:  # environment cache tied to requirements
-          key: deps9-{{ checksum "setup.py" }}
-          paths:
-            - "/opt/conda/envs/py36_env"
       - run:
-          name: Run Py2.7 tests
+          name: Run Py3.6 tests
           command: |
             source activate py36_env
             py.test rapidtide
 
-  build_py37:
+  test_py38:
+    working_directory: /tmp/src/rapidtide
+    docker:
+      - image: continuumio/miniconda3
+    steps:
+      - checkout
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+              - src/rapidtide
+      - run:  # will overwrite rapidtide installation each time
+          name: Generate environment
+          command:  |
+            if [[ -e /opt/conda/envs/py38_env ]]; then
+                echo "Restoring environment from cache"
+                source activate py38_env
+            else
+                conda create -n py38_env python=3.8 -yq
+                source activate py38_env
+                pip install -e .[tests,doc]
+            fi
+            python setup.py install --user
+      - run:
+          name: Run Py3.8 tests
+          command: |
+            source activate py38_env
+            py.test rapidtide
+
+  make_env_py37:
     working_directory: /tmp/src/rapidtide
     docker:
       - image: continuumio/miniconda3
@@ -69,35 +91,6 @@ jobs:
           key: deps9-{{ checksum "setup.py" }}
           paths:
             - "/opt/conda/envs/py37_env"
-
-  build_py38:
-    working_directory: /tmp/src/rapidtide
-    docker:
-      - image: continuumio/miniconda3
-    steps:
-      - checkout
-      - persist_to_workspace:
-          root: /tmp
-          paths:
-              - src/rapidtide
-      - restore_cache:  # ensure this step occurs *before* installing dependencies
-          key: deps9-{{ checksum "setup.py" }}
-      - run:  # will overwrite rapidtide installation each time
-          name: Generate environment
-          command:  |
-            if [[ -e /opt/conda/envs/py38_env ]]; then
-                echo "Restoring environment from cache"
-                source activate py38_env
-            else
-                conda create -n py38_env python=3.8 -yq
-                source activate py38_env
-                pip install -e .[tests,doc]
-            fi
-            python setup.py install --user
-      - save_cache:  # environment cache tied to requirements
-          key: deps9-{{ checksum "setup.py" }}
-          paths:
-            - "/opt/conda/envs/py38_env"
 
   build_docs:
     working_directory: /tmp/src/rapidtide
@@ -182,29 +175,29 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - build_py37:
+      - test_py38:
           filters:
             tags:
               only: /.*/
-      - build_py38:
+      - make_env_py37:
           filters:
             tags:
               only: /.*/
       - build_docs:
           requires:
-            - build_py37
+            - make_env_py37
           filters:
             tags:
               only: /.*/
       - style_check:
           requires:
-            - build_py37
+            - make_env_py37
           filters:
             tags:
               only: /.*/
       - test_py37_with_coverage:
           requires:
-            - build_py37
+            - make_env_py37
           filters:
             tags:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
           name: Linting
           command:  |
             source activate py37_env
-            flake8 --ignore=E501,E722,E114,E116,W503,W504 /tmp/src/rapidtide/rapidtide
+            flake8 /tmp/src/rapidtide/rapidtide
       - store_artifacts:
           path: /tmp/data/lint
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools==40.8", "wheel"]
+
+[tool.black]
+line-length = 99
+target-version = ['py37']
+include = '\.pyi?$'
+exclude = '''
+(
+  /(
+      \.eggs         # exclude a few common directories in the
+    | \.git          # root of the project
+    | \.github
+    | \.hg
+    | \.pytest_cache
+    | _build
+    | build
+    | dist
+  )/
+  | get_version.py
+  | versioneer.py
+  | nimare/info.py
+  | nimare/_version.py
+  | nimare/due.py
+)
+'''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,6 @@ exclude = '''
   )/
   | get_version.py
   | versioneer.py
-  | nimare/info.py
-  | nimare/_version.py
-  | nimare/due.py
+  | rapidtide/_version.py
 )
 '''

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,3 +13,10 @@ style = pep440
 versionfile_source = rapidtide/_version.py
 versionfile_build = rapidtide/_version.py
 tag_prefix =
+
+[flake8]
+max-line-length = 99
+exclude = *build/,_version.py,disabledtests/,candidatetests/
+putty-ignore =
+    */__init__.py : +F401
+ignore = E203,E402,E722,W503

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,16 @@ tag_prefix =
 
 [flake8]
 max-line-length = 99
-exclude = *build/,_version.py,disabledtests/,candidatetests/
+exclude =
+    *build/
+    _version.py
+    rapidtide/disabledtests/
+    rapidtide/candidatetests/
 putty-ignore =
     */__init__.py : +F401
-ignore = E203,E402,E722,W503
+ignore =
+    E203
+    E402
+    E501
+    E722
+    W503

--- a/setup.py
+++ b/setup.py
@@ -190,7 +190,7 @@ setup(
             "m2r",
             "recommonmark",
         ],
-        "tests": ["codecov", "coverage", "coveralls", "flake8", "pytest", "pytest-cov"],
+        "tests": ["codecov", "coverage", "coveralls", "flake8-black", "pytest", "pytest-cov"],
     },
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these


### PR DESCRIPTION
<!---
This is a suggested pull request template for rapidtide.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
http://rapidtide.readthedocs.io/en/latest/contributing.html#pull-requests
-->

Closes None. It looks like CI has been failing because caches were stepping on top of one another.

Changes proposed in this pull request:

- Drop `build_py38` job and replace with `test_py38` one.
- Remove caching from `test_py36` and `test_py38` jobs.
    - I'm sure there's a way to cache all three environments, but I don't know how to do it. In the meantime, only the most important one, 3.7, will be cached, and all of the others will need to be reconstructed each time CI is run.
