### PR TITLE
[INFRA] Add GitHub Action for deployment to PyPi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,67 +145,19 @@ jobs:
       - codecov/upload:
           file: /tmp/src/rapidtide/coverage.xml
 
-  deploy:
-    docker:
-      - image: continuumio/miniconda3
-    steps:
-      - checkout
-      - run:
-          name: init .pypirc
-          command: |
-            echo -e "[pypi]" >> ~/.pypirc
-            echo -e "username = $PYPI_USER" >> ~/.pypirc
-            echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
-      - run:
-          name: create package
-          command: |
-            python setup.py sdist
-            python setup.py bdist_wheel
-      - run:
-          name: upload to pypi
-          command: |
-            pip install twine
-            twine upload dist/*
-
 workflows:
   version: 2.1
   run_tests:
     jobs:
-      - test_py27:
-          filters:
-            tags:
-              only: /.*/
-      - test_py36:
-          filters:
-            tags:
-              only: /.*/
-      - build_py37:
-          filters:
-            tags:
-              only: /.*/
+      - test_py27
+      - test_py36
+      - build_py37
       - build_docs:
           requires:
             - build_py37
-          filters:
-            tags:
-              only: /.*/
       - style_check:
           requires:
             - build_py37
-          filters:
-            tags:
-              only: /.*/
       - test_py37_with_coverage:
           requires:
             - build_py37
-          filters:
-            tags:
-              only: /.*/
-      - deploy:
-          requires:
-            - test_py37_with_coverage
-          filters:
-            tags:
-              only: /[0-9]+(\.[0-9]+)*/
-            branches:
-              ignore: /.*/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,31 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.7'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*


### PR DESCRIPTION
<!---
This is a suggested pull request template for rapidtide.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
http://rapidtide.readthedocs.io/en/latest/contributing.html#pull-requests
-->

References #35. This should be the last step before making releases, but I'd rather close that issue _after_ testing the Action.

Changes proposed in this pull request:

- Remove deployment step from the CI.
- Remove the filter from the CI that would make the CI run on releases.
- Add a GitHub Action for deploying/publishing to PyPi.
