### PR TITLE
[STY] Address style issues in correlate.py

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -37,7 +37,7 @@ API
     :toctree: generated/
     :template: function.rst
 
-    rapidtide.correlate.autocorrcheck
+    rapidtide.correlate.check_autocorrelation
     rapidtide.correlate.quickcorr
     rapidtide.correlate.shorttermcorr_1D
     rapidtide.correlate.shorttermcorr_2D

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -46,7 +46,7 @@ API
     rapidtide.correlate.fastcorrelate
     rapidtide.correlate._centered
     rapidtide.correlate._check_valid_mode_shapes
-    rapidtide.correlate.weightedfftconvolve
+    rapidtide.correlate.convolve_weighted_fft
     rapidtide.correlate.gccproduct
 
 

--- a/rapidtide/correlate.py
+++ b/rapidtide/correlate.py
@@ -19,19 +19,19 @@
 # $Date: 2016/07/12 13:50:29 $
 # $Id: tide_funcs.py,v 1.4 2016/07/12 13:50:29 frederic Exp $
 """Functions for calculating correlations and similar metrics between arrays."""
+import sys
+
+import matplotlib.pyplot as plt
 import numpy as np
 import scipy as sp
+from numpy.fft import irfftn, rfftn
 from scipy import signal
-from numpy.fft import rfftn, irfftn
-import matplotlib.pyplot as plt
-
-import sys
 from sklearn.metrics import mutual_info_score
 
-import rapidtide.util as tide_util
-import rapidtide.resample as tide_resample
 import rapidtide.fit as tide_fit
 import rapidtide.miscmath as tide_math
+import rapidtide.resample as tide_resample
+import rapidtide.util as tide_util
 
 # ---------------------------------------- Global constants -------------------------------------------
 defaultbutterorder = 6

--- a/rapidtide/correlate.py
+++ b/rapidtide/correlate.py
@@ -450,7 +450,7 @@ def mutual_information_2d(
 
 
 @conditionaljit()
-def cross_MI(
+def cross_mutual_information(
     x,
     y,
     returnaxis=False,
@@ -475,7 +475,7 @@ def cross_MI(
     if bins < 1:
         bins = int(np.sqrt(len(x) / 5))
         if debug:
-            print("cross_MI: bins set to", bins)
+            print("cross_mutual_information: bins set to", bins)
 
     # find the bin locations
     if prebin:

--- a/rapidtide/correlate.py
+++ b/rapidtide/correlate.py
@@ -634,7 +634,7 @@ def cepstraldelay(data1, data2, timestep, displayplots=True):
     return timestep * np.argmax(residual_cepstrum.real[0 : len(residual_cepstrum) // 2])
 
 
-class aliasedcorrelator:
+class AliasedCorrelator:
     """An aliased correlator.
 
     Parameters

--- a/rapidtide/correlate.py
+++ b/rapidtide/correlate.py
@@ -156,26 +156,6 @@ def check_autocorrelation(
     return None, None
 
 
-def quickcorr(data1, data2, windowfunc="hamming"):
-    """Perform a sliding window correlation.
-
-    Parameters
-    ----------
-    data1
-    data2
-    windowfunc
-
-    Returns
-    -------
-    thepcorr
-    """
-    thepcorr = sp.stats.stats.pearsonr(
-        tide_math.corrnormalize(data1, detrendorder=1, windowfunc=windowfunc),
-        tide_math.corrnormalize(data2, detrendorder=1, windowfunc=windowfunc),
-    )
-    return thepcorr
-
-
 def shorttermcorr_1D(
     data1,
     data2,

--- a/rapidtide/correlate.py
+++ b/rapidtide/correlate.py
@@ -72,17 +72,6 @@ def conditionaljit():
     return resdec
 
 
-def conditionaljit2():
-    """Aggressively wrap functions in jit if number is enabled."""
-
-    def resdec(f):
-        if (not numbaexists) or donotusenumba or donotbeaggressive:
-            return f
-        return jit(f, nopython=False)
-
-    return resdec
-
-
 def disablenumba():
     """Set a global variable to disable numba."""
     global donotusenumba

--- a/rapidtide/correlate.py
+++ b/rapidtide/correlate.py
@@ -389,12 +389,21 @@ def mutual_information_2d(
     ----------
     x : 1D array
         first variable
-
     y : 1D array
         second variable
-
-    sigma: float
-        sigma for Gaussian smoothing of the joint histogram
+    sigma : float, optional
+        Sigma for Gaussian smoothing of the joint histogram.
+        Default = 1.
+    bins : tuple, optional
+    fast : bool, optional
+    normalized : bool
+        If True, this will calculate the normalized mutual information from [1]_.
+        Default = False.
+    EPS : float, optional
+        Default = 1.0e-6.
+    debug : bool, optional
+        Whether to print extra information relevant for debugging or not.
+        Default = False.
 
     Returns
     -------
@@ -404,6 +413,12 @@ def mutual_information_2d(
     Notes
     -----
     From Ionnis Pappas
+
+    References
+    ----------
+    .. [1] Studholme,  jhill & jhawkes (1998).
+           "A normalized entropy measure of 3-D medical image alignment".
+           in Proc. Medical Imaging 1998, vol. 3338, San Diego, CA, pp. 132-143.
     """
     if fast:
         xstart = bins[0][0]
@@ -437,10 +452,6 @@ def mutual_information_2d(
     HXcommaY = -np.sum(jh * np.log(jh))
     # normfac = np.min([HX, HY])
 
-    # Normalised Mutual Information of:
-    # Studholme,  jhill & jhawkes (1998).
-    # "A normalized entropy measure of 3-D medical image alignment".
-    # in Proc. Medical Imaging 1998, vol. 3338, San Diego, CA, pp. 132-143.
     if normalized:
         mi = (HX + HY) / (HXcommaY) - 1.0
     else:

--- a/rapidtide/correlate.py
+++ b/rapidtide/correlate.py
@@ -677,7 +677,7 @@ class AliasedCorrelator:
         self.aliasedsignals = {}
 
     def apply(self, loressignal, extraoffset):
-        """Apply something.
+        """Apply correlator to aliased waveform.
 
         Parameters
         ----------
@@ -833,7 +833,7 @@ def fastcorrelate(input1, input2, usefft=True, weighting="None", displayplots=Fa
         if weighting == "None":
             return signal.fftconvolve(input1, input2[::-1], mode="full")
         else:
-            return weightedfftconvolve(
+            return convolve_weighted_fft(
                 input1,
                 input2[::-1],
                 mode="full",
@@ -889,7 +889,7 @@ def _check_valid_mode_shapes(shape1, shape2):
             )
 
 
-def weightedfftconvolve(in1, in2, mode="full", weighting="None", displayplots=False):
+def convolve_weighted_fft(in1, in2, mode="full", weighting="None", displayplots=False):
     """Convolve two N-dimensional arrays using FFT.
 
     Convolve `in1` and `in2` using the fast Fourier transform method, with

--- a/rapidtide/correlate.py
+++ b/rapidtide/correlate.py
@@ -711,47 +711,6 @@ class AliasedCorrelator:
         return corrfunc
 
 
-def aliasedcorrelate(
-    hiressignal,
-    hires_Fs,
-    lowressignal,
-    lowres_Fs,
-    timerange,
-    hiresstarttime=0.0,
-    lowresstarttime=0.0,
-    padtime=30.0,
-):
-    """Perform an aliased correlation.
-
-    Parameters
-    ----------
-    hiressignal: 1D array
-        The unaliased waveform to match
-    hires_Fs: float
-        The sample rate of the unaliased waveform
-    lowressignal: 1D array
-        The aliased waveform to match
-    lowres_Fs: float
-        The sample rate of the aliased waveform
-    timerange: 1D array
-        The delays for which to calculate the correlation function
-
-    Returns
-    -------
-    corrfunc: 1D array
-        The correlation function evaluated at timepoints of timerange
-    """
-    highresaxis = np.arange(0.0, len(hiressignal)) * (1.0 / hires_Fs) - hiresstarttime
-    lowresaxis = np.arange(0.0, len(lowressignal)) * (1.0 / lowres_Fs) - lowresstarttime
-    tcgenerator = tide_resample.fastresampler(highresaxis, hiressignal, padtime=padtime)
-    targetsignal = tide_math.corrnormalize(lowressignal)
-    corrfunc = timerange * 0.0
-    for i in range(len(timerange)):
-        aliasedhiressignal = tide_math.corrnormalize(tcgenerator.yfromx(lowresaxis + timerange[i]))
-        corrfunc[i] = np.dot(aliasedhiressignal, targetsignal)
-    return corrfunc
-
-
 def arbcorr(
     input1,
     Fs1,

--- a/rapidtide/correlate.py
+++ b/rapidtide/correlate.py
@@ -918,7 +918,7 @@ def _centered(arr, newsize):
 
 
 def _check_valid_mode_shapes(shape1, shape2):
-    """Check that two shapes are 'valid' w.r.t. one another.
+    """Check that two shapes are 'valid' with respect to one another.
 
     Specifically, this checks that each item in one tuple is larger than or
     equal to corresponding item in another tuple.

--- a/rapidtide/correlate.py
+++ b/rapidtide/correlate.py
@@ -79,7 +79,7 @@ def disablenumba():
 
 
 # --------------------------- Correlation functions -------------------------------------------------
-def autocorrcheck(
+def check_autocorrelation(
     corrscale,
     thexcorr,
     delta=0.1,

--- a/rapidtide/correlate.py
+++ b/rapidtide/correlate.py
@@ -37,6 +37,7 @@ import rapidtide.util as tide_util
 defaultbutterorder = 6
 MAXLINES = 10000000
 donotbeaggressive = True
+donotusenumba = False
 
 # ----------------------------------------- Conditional imports ---------------------------------------
 try:
@@ -46,8 +47,6 @@ try:
 except ImportError:
     numbaexists = False
 numbaexists = False
-
-donotusenumba = False
 
 try:
     import pyfftw
@@ -367,7 +366,7 @@ def calc_MI(x, y, bins=50):
 
 
 @conditionaljit()
-def mutual_information_2d(
+def mutual_info_2d(
     x, y, sigma=1, bins=(256, 256), fast=False, normalized=True, EPS=1.0e-6, debug=False
 ):
     """Compute (normalized) mutual information between two 1D variate from a joint histogram.
@@ -450,7 +449,7 @@ def mutual_information_2d(
 
 
 @conditionaljit()
-def cross_mutual_information(
+def cross_mutual_info(
     x,
     y,
     returnaxis=False,
@@ -475,7 +474,7 @@ def cross_mutual_information(
     if bins < 1:
         bins = int(np.sqrt(len(x) / 5))
         if debug:
-            print("cross_mutual_information: bins set to", bins)
+            print("cross_mutual_info: bins set to", bins)
 
     # find the bin locations
     if prebin:
@@ -508,7 +507,7 @@ def cross_mutual_information(
         else:
             destloc += 1
         if i < 0:
-            thexmi_y[destloc] = mutual_information_2d(
+            thexmi_y[destloc] = mutual_info_2d(
                 normx[: i + len(normy)],
                 normy[-i:],
                 bins=bins2d,
@@ -518,7 +517,7 @@ def cross_mutual_information(
                 debug=debug,
             )
         elif i == 0:
-            thexmi_y[destloc] = mutual_information_2d(
+            thexmi_y[destloc] = mutual_info_2d(
                 normx,
                 normy,
                 bins=bins2d,
@@ -528,7 +527,7 @@ def cross_mutual_information(
                 debug=debug,
             )
         else:
-            thexmi_y[destloc] = mutual_information_2d(
+            thexmi_y[destloc] = mutual_info_2d(
                 normx[i:],
                 normy[: len(normy) - i],
                 bins=bins2d,
@@ -555,7 +554,7 @@ def cross_mutual_information(
         return thexmi_y
 
 
-def MI_to_R(themi, d=1):
+def mutual_info_to_r(themi, d=1):
     """Convert mutual information to Pearson product-moment correlation."""
     return np.power(1.0 - np.exp(-2.0 * themi / d), -0.5)
 

--- a/rapidtide/correlate.py
+++ b/rapidtide/correlate.py
@@ -645,7 +645,7 @@ def cepstraldelay(data1, data2, timestep, displayplots=True):
     return timestep * np.argmax(residual_cepstrum.real[0 : len(residual_cepstrum) // 2])
 
 
-class aliasedcorrelator(object):
+class aliasedcorrelator:
     """An aliased correlator.
 
     Parameters

--- a/rapidtide/correlate.py
+++ b/rapidtide/correlate.py
@@ -19,8 +19,6 @@
 # $Date: 2016/07/12 13:50:29 $
 # $Id: tide_funcs.py,v 1.4 2016/07/12 13:50:29 frederic Exp $
 """Functions for calculating correlations and similar metrics between arrays."""
-from __future__ import print_function, division
-
 import numpy as np
 import scipy as sp
 from scipy import signal

--- a/rapidtide/data/examples/src/testcrossMI
+++ b/rapidtide/data/examples/src/testcrossMI
@@ -31,7 +31,7 @@ for windowfunc in ["None"]:
         for numbins in [10]:
             starttime = time.perf_counter()
             for i in range(numruns):
-                thex, thexmi, dummy = tide_corr.cross_MI(
+                thex, thexmi, dummy = tide_corr.cross_mutual_information(
                     input3,
                     input3,
                     negsteps=200,
@@ -47,13 +47,13 @@ for windowfunc in ["None"]:
                 )
             endtime = time.perf_counter()
             print(
-                "time per cross_MI call with no optimizations:",
+                "time per cross_mutual_information call with no optimizations:",
                 1000.0 * (endtime - starttime) / numruns,
                 "ms",
             )
             starttime = time.perf_counter()
             for i in range(numruns):
-                theprebinx, theprebinxmi, dummy = tide_corr.cross_MI(
+                theprebinx, theprebinxmi, dummy = tide_corr.cross_mutual_information(
                     input3,
                     input3,
                     negsteps=200,
@@ -69,13 +69,13 @@ for windowfunc in ["None"]:
                 )
             endtime = time.perf_counter()
             print(
-                "time per cross_MI call with prebinning:",
+                "time per cross_mutual_information call with prebinning:",
                 1000.0 * (endtime - starttime) / numruns,
                 "ms",
             )
             starttime = time.perf_counter()
             for i in range(numruns):
-                thefastx, thefastxmi, dummy = tide_corr.cross_MI(
+                thefastx, thefastxmi, dummy = tide_corr.cross_mutual_information(
                     input3,
                     input3,
                     negsteps=200,
@@ -91,7 +91,7 @@ for windowfunc in ["None"]:
                 )
             endtime = time.perf_counter()
             print(
-                "time per cross_MI call with prebinning and bincount:",
+                "time per cross_mutual_information call with prebinning and bincount:",
                 1000.0 * (endtime - starttime) / numruns,
                 "ms",
             )

--- a/rapidtide/data/examples/src/testcrossMI
+++ b/rapidtide/data/examples/src/testcrossMI
@@ -31,7 +31,7 @@ for windowfunc in ["None"]:
         for numbins in [10]:
             starttime = time.perf_counter()
             for i in range(numruns):
-                thex, thexmi, dummy = tide_corr.cross_mutual_information(
+                thex, thexmi, dummy = tide_corr.cross_mutual_info(
                     input3,
                     input3,
                     negsteps=200,
@@ -47,13 +47,13 @@ for windowfunc in ["None"]:
                 )
             endtime = time.perf_counter()
             print(
-                "time per cross_mutual_information call with no optimizations:",
+                "time per cross_mutual_info call with no optimizations:",
                 1000.0 * (endtime - starttime) / numruns,
                 "ms",
             )
             starttime = time.perf_counter()
             for i in range(numruns):
-                theprebinx, theprebinxmi, dummy = tide_corr.cross_mutual_information(
+                theprebinx, theprebinxmi, dummy = tide_corr.cross_mutual_info(
                     input3,
                     input3,
                     negsteps=200,
@@ -69,13 +69,13 @@ for windowfunc in ["None"]:
                 )
             endtime = time.perf_counter()
             print(
-                "time per cross_mutual_information call with prebinning:",
+                "time per cross_mutual_info call with prebinning:",
                 1000.0 * (endtime - starttime) / numruns,
                 "ms",
             )
             starttime = time.perf_counter()
             for i in range(numruns):
-                thefastx, thefastxmi, dummy = tide_corr.cross_mutual_information(
+                thefastx, thefastxmi, dummy = tide_corr.cross_mutual_info(
                     input3,
                     input3,
                     negsteps=200,
@@ -91,7 +91,7 @@ for windowfunc in ["None"]:
                 )
             endtime = time.perf_counter()
             print(
-                "time per cross_mutual_information call with prebinning and bincount:",
+                "time per cross_mutual_info call with prebinning and bincount:",
                 1000.0 * (endtime - starttime) / numruns,
                 "ms",
             )

--- a/rapidtide/data/examples/src/testentropy
+++ b/rapidtide/data/examples/src/testentropy
@@ -48,7 +48,7 @@ for windowfunc in ["None"]:
             for wave1 in [combo]:
                 j = 0
                 for offset in np.linspace(-3.0, 3.0, num=7, endpoint=True):
-                    thefastx, thefastxmi, dummy = tide_corr.cross_MI(
+                    thefastx, thefastxmi, dummy = tide_corr.cross_mutual_information(
                         wave1,
                         addresp(lfowave, samplefreq, respfreq, respamp, offset),
                         negsteps=200,
@@ -79,7 +79,7 @@ for windowfunc in ["None"]:
             for wave1 in [combo]:
                 j = 0
                 for offset in np.linspace(-3.0, 3.0, num=7, endpoint=True):
-                    thecorrx, thecorry, dummy = tide_corr.cross_MI(
+                    thecorrx, thecorry, dummy = tide_corr.cross_mutual_information(
                         wave1,
                         addresp(lfowave, samplefreq, respfreq, respamp, offset),
                         negsteps=200,

--- a/rapidtide/data/examples/src/testentropy
+++ b/rapidtide/data/examples/src/testentropy
@@ -48,7 +48,7 @@ for windowfunc in ["None"]:
             for wave1 in [combo]:
                 j = 0
                 for offset in np.linspace(-3.0, 3.0, num=7, endpoint=True):
-                    thefastx, thefastxmi, dummy = tide_corr.cross_mutual_information(
+                    thefastx, thefastxmi, dummy = tide_corr.cross_mutual_info(
                         wave1,
                         addresp(lfowave, samplefreq, respfreq, respamp, offset),
                         negsteps=200,
@@ -79,7 +79,7 @@ for windowfunc in ["None"]:
             for wave1 in [combo]:
                 j = 0
                 for offset in np.linspace(-3.0, 3.0, num=7, endpoint=True):
-                    thecorrx, thecorry, dummy = tide_corr.cross_mutual_information(
+                    thecorrx, thecorry, dummy = tide_corr.cross_mutual_info(
                         wave1,
                         addresp(lfowave, samplefreq, respfreq, respamp, offset),
                         negsteps=200,

--- a/rapidtide/helper_classes.py
+++ b/rapidtide/helper_classes.py
@@ -263,7 +263,7 @@ class mutualinformationator(similarityfunctionator):
         self.reftc = reftc + 0.0
         self.prepreftc = self.preptc(self.reftc, hpfreq=None)
 
-        self.timeaxis, dummy, self.similarityfuncorigin = tide_corr.cross_MI(
+        self.timeaxis, dummy, self.similarityfuncorigin = tide_corr.cross_mutual_information(
             self.prepreftc,
             self.prepreftc,
             Fs=self.Fs,
@@ -300,7 +300,7 @@ class mutualinformationator(similarityfunctionator):
 
         # now calculate the similarity function
         if trim:
-            retvals = tide_corr.cross_MI(
+            retvals = tide_corr.cross_mutual_information(
                 self.preptesttc,
                 self.prepreftc,
                 norm=self.norm,
@@ -315,7 +315,7 @@ class mutualinformationator(similarityfunctionator):
                 bins=self.bins,
             )
         else:
-            retvals = tide_corr.cross_MI(
+            retvals = tide_corr.cross_mutual_information(
                 self.preptesttc,
                 self.prepreftc,
                 norm=self.norm,

--- a/rapidtide/helper_classes.py
+++ b/rapidtide/helper_classes.py
@@ -263,7 +263,7 @@ class mutualinformationator(similarityfunctionator):
         self.reftc = reftc + 0.0
         self.prepreftc = self.preptc(self.reftc, hpfreq=None)
 
-        self.timeaxis, dummy, self.similarityfuncorigin = tide_corr.cross_mutual_information(
+        self.timeaxis, dummy, self.similarityfuncorigin = tide_corr.cross_mutual_info(
             self.prepreftc,
             self.prepreftc,
             Fs=self.Fs,
@@ -300,7 +300,7 @@ class mutualinformationator(similarityfunctionator):
 
         # now calculate the similarity function
         if trim:
-            retvals = tide_corr.cross_mutual_information(
+            retvals = tide_corr.cross_mutual_info(
                 self.preptesttc,
                 self.prepreftc,
                 norm=self.norm,
@@ -315,7 +315,7 @@ class mutualinformationator(similarityfunctionator):
                 bins=self.bins,
             )
         else:
-            retvals = tide_corr.cross_mutual_information(
+            retvals = tide_corr.cross_mutual_info(
                 self.preptesttc,
                 self.prepreftc,
                 norm=self.norm,

--- a/rapidtide/scripts/showxcorrx
+++ b/rapidtide/scripts/showxcorrx
@@ -558,7 +558,7 @@ def main():
                     thepeaks[thesortedindices[i]][0],
                     thepeaks[thesortedindices[i]][1],
                     thepeaks[thesortedindices[i]][2],
-                    tide_corr.MI_to_R(thepeaks[thesortedindices[i]][2]),
+                    tide_corr.mutual_info_to_r(thepeaks[thesortedindices[i]][2]),
                 )
             )
 

--- a/rapidtide/tests/test_aliasedcorrelate.py
+++ b/rapidtide/tests/test_aliasedcorrelate.py
@@ -22,7 +22,7 @@ import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 
-from rapidtide.correlate import aliasedcorrelate, aliasedcorrelator
+from rapidtide.correlate import aliasedcorrelate, AliasedCorrelator
 
 
 def test_aliasedcorrelate(display=False):
@@ -47,7 +47,7 @@ def test_aliasedcorrelate(display=False):
         sighi, Fs_hi, siglo, Fs_lo, timerange, padtime=width
     )
 
-    thecorrelator = aliasedcorrelator(sighi, Fs_hi, Fs_lo, timerange, padtime=width)
+    thecorrelator = AliasedCorrelator(sighi, Fs_hi, Fs_lo, timerange, padtime=width)
     aliasedcorrelate_result2 = thecorrelator.apply(siglo, 0.0)
 
     if display:

--- a/rapidtide/tests/test_aliasedcorrelate.py
+++ b/rapidtide/tests/test_aliasedcorrelate.py
@@ -22,7 +22,53 @@ import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 
-from rapidtide.correlate import aliasedcorrelate, AliasedCorrelator
+import rapitide.miscmath as tide_math
+import rapidtide.resample as tide_resample
+from rapidtide.correlate import AliasedCorrelator
+
+
+def aliasedcorrelate(
+    hiressignal,
+    hires_Fs,
+    lowressignal,
+    lowres_Fs,
+    timerange,
+    hiresstarttime=0.0,
+    lowresstarttime=0.0,
+    padtime=30.0,
+):
+    """Perform an aliased correlation.
+
+    This function is deprecated, and is retained here as a reference against
+    which to test AliasedCorrelator.
+
+    Parameters
+    ----------
+    hiressignal: 1D array
+        The unaliased waveform to match
+    hires_Fs: float
+        The sample rate of the unaliased waveform
+    lowressignal: 1D array
+        The aliased waveform to match
+    lowres_Fs: float
+        The sample rate of the aliased waveform
+    timerange: 1D array
+        The delays for which to calculate the correlation function
+
+    Returns
+    -------
+    corrfunc: 1D array
+        The correlation function evaluated at timepoints of timerange
+    """
+    highresaxis = np.arange(0.0, len(hiressignal)) * (1.0 / hires_Fs) - hiresstarttime
+    lowresaxis = np.arange(0.0, len(lowressignal)) * (1.0 / lowres_Fs) - lowresstarttime
+    tcgenerator = tide_resample.fastresampler(highresaxis, hiressignal, padtime=padtime)
+    targetsignal = tide_math.corrnormalize(lowressignal)
+    corrfunc = timerange * 0.0
+    for i in range(len(timerange)):
+        aliasedhiressignal = tide_math.corrnormalize(tcgenerator.yfromx(lowresaxis + timerange[i]))
+        corrfunc[i] = np.dot(aliasedhiressignal, targetsignal)
+    return corrfunc
 
 
 def test_aliasedcorrelate(display=False):

--- a/rapidtide/tests/test_aliasedcorrelate.py
+++ b/rapidtide/tests/test_aliasedcorrelate.py
@@ -22,7 +22,7 @@ import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 
-import rapitide.miscmath as tide_math
+import rapidtide.miscmath as tide_math
 import rapidtide.resample as tide_resample
 from rapidtide.correlate import AliasedCorrelator
 

--- a/rapidtide/workflows/happy.py
+++ b/rapidtide/workflows/happy.py
@@ -2079,7 +2079,7 @@ def happy_main(argparsingfunc):
                 np.linspace(0.0, args.aliasedcorrelationwidth, num=args.aliasedcorrelationpts)
                 - args.aliasedcorrelationwidth / 2.0
             )
-            thecorrelator = tide_corr.aliasedcorrelator(
+            thecorrelator = tide_corr.AliasedCorrelator(
                 signal_sliceres,
                 slicesamplerate,
                 mrsamplerate,

--- a/rapidtide/workflows/happy_legacy.py
+++ b/rapidtide/workflows/happy_legacy.py
@@ -2513,7 +2513,7 @@ def happy_main(thearguments):
                 np.linspace(0.0, aliasedcorrelationwidth, num=aliasedcorrelationpts)
                 - aliasedcorrelationwidth / 2.0
             )
-            thecorrelator = tide_corr.aliasedcorrelator(
+            thecorrelator = tide_corr.AliasedCorrelator(
                 signal_stdres,
                 stdfreq,
                 mrsamplerate,

--- a/rapidtide/workflows/rapidtide.py
+++ b/rapidtide/workflows/rapidtide.py
@@ -1466,7 +1466,7 @@ def rapidtide_main(argparsingfunc):
                 thelagthresh,
                 "s",
             )
-            sidelobetime, sidelobeamp = tide_corr.autocorrcheck(
+            sidelobetime, sidelobeamp = tide_corr.check_autocorrelation(
                 accheckcorrscale,
                 thexcorr,
                 acampthresh=theampthresh,
@@ -1483,7 +1483,7 @@ def rapidtide_main(argparsingfunc):
                 )
                 optiondict["acsidelobeamp" + passsuffix] = sidelobeamp
                 print(
-                    "\n\nWARNING: autocorrcheck found bad sidelobe at",
+                    "\n\nWARNING: check_autocorrelation found bad sidelobe at",
                     sidelobetime,
                     "seconds (",
                     1.0 / sidelobetime,

--- a/setup.py
+++ b/setup.py
@@ -200,6 +200,8 @@ setup(
             "reference/HCP1200*",
             "reference/MNI152*",
         ],
+    },
+     additional_packagedata={
         "testdata": [
             "tests/testdata/*.txt",
         ],


### PR DESCRIPTION
<!---
This is a suggested pull request template for rapidtide.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
http://rapidtide.readthedocs.io/en/latest/contributing.html#pull-requests
-->

Closes None. This is an _initial_ attempt at _starting_ to address the style issues identified by the linter, and by `flake8-docstring`, which I use in my editor.

If this PR looks okay to you, I can do something similar to other modules over time. If not, that's cool too.

Changes proposed in this pull request:

- Remove unused conditional imports for `memory_profiler` and `nibabel`.
     - On a related note, `nibabel` is a required dependency at this point, so I think you can get rid of any `nibabel`-related conditional imports across the package.
- Add module-level docstring.
- Simplify (hopefully) fftpack import. It was raising the following issue in the linter: `F811 redefinition of unused 'fftpack' from line 26`.
- Add docstrings where I could. There are a few functions where I couldn't infer the actual purpose, so I said something useless like "Apply/Calculate something." I will add inline comments to request clarification.
- Move some comments to the docstrings where it seemed appropriate.