### PR TITLE
[REF] Use logging instead of printed statements

### DIFF
--- a/rapidtide/workflows/rapidtide.py
+++ b/rapidtide/workflows/rapidtide.py
@@ -212,15 +212,12 @@ def getglobalsignal(indata, optiondict, includemask=None, excludemask=None, pcac
             else:
                 LGR.warning("unhandled math exception in PCA refinement - exiting")
                 sys.exit()
+        varex = 100.0 * np.cumsum(thefit.explained_variance_ratio_)[len(thefit.components_) - 1]
         LGR.info(
-            "Using ",
-            len(thefit.components_),
-            " components, accounting for ",
-            "{:.2f}% of the variance".format(
-                100.0 * np.cumsum(thefit.explained_variance_ratio_)[len(thefit.components_) - 1]
-            ),
+            f"Using {len(thefit.components_)} components, accounting for "
+            f"{varex:.2f}% of the variance"
         )
-    LGR.info("used ", numvoxelsused, " voxels to calculate global mean signal")
+    LGR.info(f"used {numvoxelsused} voxels to calculate global mean signal")
     return tide_math.stdnormalize(globalmean), themask
 
 
@@ -434,7 +431,9 @@ def rapidtide_main(argparsingfunc):
     else:
         if optiondict["textio"]:
             if optiondict["realtr"] <= 0.0:
-                LGR.info("for text file data input, you must use the -t option to set the timestep")
+                LGR.error(
+                    "for text file data input, you must use the -t option to set the timestep"
+                )
                 sys.exit()
         else:
             if nim_hdr.get_xyzt_units()[1] == "msec":
@@ -672,8 +671,7 @@ def rapidtide_main(argparsingfunc):
     LGR.info("validvoxels shape =", numvalidspatiallocs)
     fmri_data_valid = fmri_data[validvoxels, :] + 0.0
     LGR.info(
-        f"original size = {np.shape(fmri_data)}, "
-        f"trimmed size = {np.shape(fmri_data_valid)}"
+        f"original size = {np.shape(fmri_data)}, " f"trimmed size = {np.shape(fmri_data_valid)}"
     )
     if internalglobalmeanincludemask is not None:
         internalglobalmeanincludemask_valid = 1.0 * internalglobalmeanincludemask[validvoxels]
@@ -1105,7 +1103,7 @@ def rapidtide_main(argparsingfunc):
     lagmaxinpts = int((optiondict["lagmax"] / corrtr) + 0.5)
 
     if (lagmaxinpts + lagmininpts) < 3:
-        LGR.info(
+        LGR.error(
             "correlation search range is too narrow - decrease lagmin, increase lagmax, or increase oversample factor"
         )
         sys.exit(1)
@@ -2022,7 +2020,7 @@ def rapidtide_main(argparsingfunc):
                         names=["despecklemask"],
                     )
             LGR.info(
-                f"\n\n{voxelsprocessed_fc_ds} voxels despeckled in ",
+                f"\n\n{voxelsprocessed_fc_ds} voxels despeckled in "
                 f"{optiondict['despeckle_passes']} passes"
             )
             timings.append(
@@ -2131,9 +2129,7 @@ def rapidtide_main(argparsingfunc):
                 # check for convergence
                 regressormse = mse(normoutputdata, previousnormoutputdata)
                 optiondict["regressormse_pass" + str(thepass).zfill(2)] = regressormse
-                LGR.info(
-                    f"regressor difference at end of pass {thepass:d} is {regressormse:.6f}"
-                )
+                LGR.info(f"regressor difference at end of pass {thepass:d} is {regressormse:.6f}")
                 if optiondict["convergencethresh"] is not None:
                     if thepass >= optiondict["maxpasses"]:
                         LGR.info("refinement ended (maxpasses reached")
@@ -2442,9 +2438,7 @@ def rapidtide_main(argparsingfunc):
         reportstep = 1000
         if (optiondict["gausssigma"] > 0.0) or (optiondict["glmsourcefile"] is not None):
             if optiondict["glmsourcefile"] is not None:
-                LGR.info(
-                    f"reading in {optiondict['glmsourcefile']} for GLM filter, please wait"
-                )
+                LGR.info(f"reading in {optiondict['glmsourcefile']} for GLM filter, please wait")
                 if optiondict["textio"]:
                     nim_data = tide_io.readvecs(optiondict["glmsourcefile"])
                 else:

--- a/rapidtide/workflows/rapidtide.py
+++ b/rapidtide/workflows/rapidtide.py
@@ -408,11 +408,7 @@ def rapidtide_main(argparsingfunc):
             timepoints = nim_data.shape[1]
             numspatiallocs = nim_data.shape[0]
             LGR.info(
-                "cifti file has",
-                timepoints,
-                "timepoints, ",
-                numspatiallocs,
-                "numspatiallocs",
+                f"cifti file has {timepoints} timepoints, {numspatiallocs} numspatiallocs"
             )
             slicesize = numspatiallocs
         else:
@@ -671,14 +667,14 @@ def rapidtide_main(argparsingfunc):
     LGR.info("validvoxels shape =", numvalidspatiallocs)
     fmri_data_valid = fmri_data[validvoxels, :] + 0.0
     LGR.info(
-        f"original size = {np.shape(fmri_data)}, " f"trimmed size = {np.shape(fmri_data_valid)}"
+        f"original size = {np.shape(fmri_data)}, trimmed size = {np.shape(fmri_data_valid)}"
     )
     if internalglobalmeanincludemask is not None:
         internalglobalmeanincludemask_valid = 1.0 * internalglobalmeanincludemask[validvoxels]
         del internalglobalmeanincludemask
         LGR.info(
-            "internalglobalmeanincludemask_valid has size:",
-            internalglobalmeanincludemask_valid.size,
+            "internalglobalmeanincludemask_valid has size: "
+            f"{internalglobalmeanincludemask_valid.size}"
         )
     else:
         internalglobalmeanincludemask_valid = None
@@ -686,8 +682,8 @@ def rapidtide_main(argparsingfunc):
         internalglobalmeanexcludemask_valid = 1.0 * internalglobalmeanexcludemask[validvoxels]
         del internalglobalmeanexcludemask
         LGR.info(
-            "internalglobalmeanexcludemask_valid has size:",
-            internalglobalmeanexcludemask_valid.size,
+            "internalglobalmeanexcludemask_valid has size: "
+            f"{internalglobalmeanexcludemask_valid.size}"
         )
     else:
         internalglobalmeanexcludemask_valid = None
@@ -695,8 +691,8 @@ def rapidtide_main(argparsingfunc):
         internalrefineincludemask_valid = 1.0 * internalrefineincludemask[validvoxels]
         del internalrefineincludemask
         LGR.info(
-            "internalrefineincludemask_valid has size:",
-            internalrefineincludemask_valid.size,
+            "internalrefineincludemask_valid has size: "
+            f"{internalrefineincludemask_valid.size}"
         )
     else:
         internalrefineincludemask_valid = None
@@ -704,8 +700,8 @@ def rapidtide_main(argparsingfunc):
         internalrefineexcludemask_valid = 1.0 * internalrefineexcludemask[validvoxels]
         del internalrefineexcludemask
         LGR.info(
-            "internalrefineexcludemask_valid has size:",
-            internalrefineexcludemask_valid.size,
+            "internalrefineexcludemask_valid has size: "
+            f"{internalrefineexcludemask_valid.size}"
         )
     else:
         internalrefineexcludemask_valid = None
@@ -838,8 +834,8 @@ def rapidtide_main(argparsingfunc):
         inputfreq = optiondict["inputfreq"]
         inputstarttime = optiondict["inputstarttime"]
         if inputfreq is None:
-            LGR.warning("no regressor frequency specified - defaulting to 1/tr")
             inputfreq = 1.0 / fmritr
+            LGR.warning(f"no regressor frequency specified - defaulting to {inputfreq} (1/tr)")
         if inputstarttime is None:
             LGR.warning("no regressor start time specified - defaulting to 0.0")
             inputstarttime = 0.0
@@ -904,7 +900,7 @@ def rapidtide_main(argparsingfunc):
     if os_fmri_x[0] < reference_x[0]:
         LGR.warning(
             f"WARNING: extrapolating {os_fmri_x[0] - reference_x[0]} "
-            "seconds of data at beginning of timecourse",
+            "seconds of data at beginning of timecourse"
         )
     if os_fmri_x[-1] > reference_x[-1]:
         LGR.warning(
@@ -1135,7 +1131,7 @@ def rapidtide_main(argparsingfunc):
     LGR.verbose(f"corrorigin at point {corrorigin} {corrscale[corrorigin]}")
     LGR.verbose(
         f"corr range from {corrorigin - lagmininpts} ({corrscale[corrorigin - lagmininpts]}) "
-        f"to {corrorigin + lagmaxinpts} ({corrscale[corrorigin + lagmaxinpts]})",
+        f"to {corrorigin + lagmaxinpts} ({corrscale[corrorigin + lagmaxinpts]})"
     )
 
     if optiondict["savecorrtimes"]:
@@ -3058,7 +3054,7 @@ def rapidtide_main(argparsingfunc):
         timings, outputfile=outputname + "_runtimings.txt", extraheader=nodeline
     )
     optiondict["totalruntime"] = timings[-1][1] - timings[0][1]
-    optiondict["maxrss"] = tide_util.logmem("status", file=None).split(",")[1]
+    tide_util.logmem("status")
 
     # do a final save of the options file
     if optiondict["bidsoutput"]:

--- a/rapidtide/workflows/utils.py
+++ b/rapidtide/workflows/utils.py
@@ -10,8 +10,8 @@ MemoryLGR = logging.getLogger("MEMORY")
 class ContextFilter(logging.Filter):
     """A filter to allow specific logging handlers to ignore specific loggers.
 
-    We use this to prevent our report-generation and reference-compiling
-    loggers from printing to the general log file or to stdout.
+    We use this to prevent our secondary loggers from printing to the general log file or to
+    stdout.
     """
 
     NAMES = {"TIMING", "MEMORY"}
@@ -22,22 +22,28 @@ class ContextFilter(logging.Filter):
 
 
 def setup_logger(logger_filename, timing_filename, memory_filename, verbose=False, debug=False):
-    """Set up a logger."""
+    """Set up a set of loggers.
+
+    Parameters
+    ----------
+    logger_filename : str
+        Output file for generic logging information.
+    timing_filename : str
+        Output file for timing-related information.
+    memory_filename : str
+        Output file for memory usage-related information.
+    verbose : bool, optional
+        Sets the target logging level to VERBOSE (a custom level between INFO and DEBUG).
+        Is overridden by ``debug``, if ``debug = True``.
+        Default is False.
+    debug : bool, optional
+        Sets the target logging level to DEBUG. Default is False.
+    """
+    # Clean up existing files from previous runs
     for fname in [logger_filename, timing_filename, memory_filename]:
         if os.path.isfile(fname):
             LGR.info(f"Removing existing file: {fname}")
             os.remove(fname)
-
-    # set logging format
-    log_formatter = logging.Formatter(
-        "%(asctime)s\t%(name)-12s\t%(levelname)-8s\t%(message)s",
-        datefmt="%Y-%m-%dT%H:%M:%S",
-    )
-    timing_formatter = logging.Formatter(
-        "%(asctime)s\t%(message)s",
-        datefmt="%Y-%m-%dT%H:%M:%S",
-    )
-    memory_formatter = logging.Formatter("%(message)s")
 
     # Create a new "verbose" logging level
     VERBOSE_LEVEL = 15  # between info and debug
@@ -49,18 +55,7 @@ def setup_logger(logger_filename, timing_filename, memory_filename, verbose=Fals
 
     logging.Logger.verbose = verbose
 
-    # set up logging file and open it for writing
-    log_handler = logging.FileHandler(logger_filename)
-    log_handler.setFormatter(log_formatter)
-
-    # Removing handlers after basicConfig doesn't work, so we use filters
-    # for the relevant handlers themselves.
-    log_handler.addFilter(ContextFilter())
-    logging.root.addHandler(log_handler)
-    stream_handler = logging.StreamHandler()
-    stream_handler.addFilter(ContextFilter())
-    logging.root.addHandler(stream_handler)
-
+    # Set logging level for main logger
     if debug:
         logging.root.setLevel(logging.DEBUG)
     elif verbose:
@@ -68,13 +63,38 @@ def setup_logger(logger_filename, timing_filename, memory_filename, verbose=Fals
     else:
         logging.root.setLevel(logging.INFO)
 
-    # Loggers for timing and memory usage
+    # Set up handler for main logger's output file
+    log_formatter = logging.Formatter(
+        "%(asctime)s\t%(name)-12s\t%(levelname)-8s\t%(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+    log_handler = logging.FileHandler(logger_filename)
+    log_handler.setFormatter(log_formatter)
+
+    # A handler for the console
+    stream_handler = logging.StreamHandler()
+
+    # Removing handlers after basicConfig doesn't work, so we use filters
+    # for the relevant handlers themselves.
+    log_handler.addFilter(ContextFilter())
+    stream_handler.addFilter(ContextFilter())
+
+    logging.root.addHandler(log_handler)
+    logging.root.addHandler(stream_handler)
+
+    # A timing logger
+    timing_formatter = logging.Formatter(
+        "%(asctime)s\t%(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
     timing_handler = logging.FileHandler(timing_filename)
     timing_handler.setFormatter(timing_formatter)
     TimingLGR.setLevel(logging.INFO)
     TimingLGR.addHandler(timing_handler)
     TimingLGR.propagate = False  # do not print to console
 
+    # A memory logger
+    memory_formatter = logging.Formatter("%(message)s")
     memory_handler = logging.FileHandler(memory_filename)
     memory_handler.setFormatter(memory_formatter)
     MemoryLGR.setLevel(logging.INFO)

--- a/rapidtide/workflows/utils.py
+++ b/rapidtide/workflows/utils.py
@@ -1,0 +1,82 @@
+"""Utility functions for rapidtide workflows."""
+import logging
+import os
+
+LGR = logging.getLogger(__name__)
+TimingLGR = logging.getLogger("TIMING")
+MemoryLGR = logging.getLogger("MEMORY")
+
+
+class ContextFilter(logging.Filter):
+    """A filter to allow specific logging handlers to ignore specific loggers.
+
+    We use this to prevent our report-generation and reference-compiling
+    loggers from printing to the general log file or to stdout.
+    """
+
+    NAMES = {"TIMING", "MEMORY"}
+
+    def filter(self, record):
+        if not any([n in record.name for n in self.NAMES]):
+            return True
+
+
+def setup_logger(logger_filename, timing_filename, memory_filename, verbose=False, debug=False):
+    """Set up a logger."""
+    for fname in [logger_filename, timing_filename, memory_filename]:
+        if os.path.isfile(fname):
+            LGR.info(f"Removing existing file: {fname}")
+            os.remove(fname)
+
+    # set logging format
+    log_formatter = logging.Formatter(
+        "%(asctime)s\t%(name)-12s\t%(levelname)-8s\t%(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+    timing_formatter = logging.Formatter(
+        "%(asctime)s\t%(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+    memory_formatter = logging.Formatter("%(message)s")
+
+    # Create a new "verbose" logging level
+    VERBOSE_LEVEL = 15  # between info and debug
+    logging.addLevelName(VERBOSE_LEVEL, "VERBOSE")
+
+    def verbose(self, message, *args, **kwargs):
+        if self.isEnabledFor(VERBOSE_LEVEL):
+            self._log(VERBOSE_LEVEL, message, args, **kwargs)
+
+    logging.Logger.verbose = verbose
+
+    # set up logging file and open it for writing
+    log_handler = logging.FileHandler(logger_filename)
+    log_handler.setFormatter(log_formatter)
+
+    # Removing handlers after basicConfig doesn't work, so we use filters
+    # for the relevant handlers themselves.
+    log_handler.addFilter(ContextFilter())
+    logging.root.addHandler(log_handler)
+    stream_handler = logging.StreamHandler()
+    stream_handler.addFilter(ContextFilter())
+    logging.root.addHandler(stream_handler)
+
+    if debug:
+        logging.root.setLevel(logging.DEBUG)
+    elif verbose:
+        logging.root.setLevel(VERBOSE_LEVEL)
+    else:
+        logging.root.setLevel(logging.INFO)
+
+    # Loggers for timing and memory usage
+    timing_handler = logging.FileHandler(timing_filename)
+    timing_handler.setFormatter(timing_formatter)
+    TimingLGR.setLevel(logging.INFO)
+    TimingLGR.addHandler(timing_handler)
+    TimingLGR.propagate = False  # do not print to console
+
+    memory_handler = logging.FileHandler(memory_filename)
+    memory_handler.setFormatter(memory_formatter)
+    MemoryLGR.setLevel(logging.INFO)
+    MemoryLGR.addHandler(memory_handler)
+    MemoryLGR.propagate = False  # do not print to console


### PR DESCRIPTION
<!---
This is a suggested pull request template for rapidtide.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
http://rapidtide.readthedocs.io/en/latest/contributing.html#pull-requests
-->

Closes #41.

To do:

- [ ] Finish converting timing logger
- [ ] Add additional fields (variables and voxel counts) to timing logger
- [ ] Convert general logger's formatter to freeform text
- [ ] Finish converting memory usage logger
- [ ] Figure out how to handle `memprofile` with memory usage logger. I'm still not sure what it's for, but I'll figure it out.
- [ ] Remove sys.exit statements.

Changes proposed in this pull request:

- Replace print statements in rapidtide workflow with logged messages.
- Remove `verbose` and `debug` if statements. The logger natively handles different levels of messages, although I _did_ have to add a new level for the verbose messages.
- Replace timing and memory usage trackers with additional, separate loggers.
- Streamline `fftpack` import. Will need to be propagated across the package.
- Use f-strings instead of concatenating strings, when appropriate.
