### PR TITLE
[REF] Continue shifting to logging

### DIFF
--- a/rapidtide/calcsimfunc.py
+++ b/rapidtide/calcsimfunc.py
@@ -23,6 +23,7 @@
 #
 #
 import gc
+import logging
 import warnings
 
 import numpy as np
@@ -32,6 +33,7 @@ import rapidtide.resample as tide_resample
 import rapidtide.util as tide_util
 
 warnings.simplefilter(action="ignore", category=FutureWarning)
+LGR = logging.getLogger(__name__)
 
 
 def _procOneVoxelCorrelation(
@@ -73,7 +75,6 @@ def correlationpass(
     chunksize=1000,
     rt_floatset=np.float64,
     rt_floattype="float64",
-    debug=False,
 ):
     """
 
@@ -184,10 +185,10 @@ def correlationpass(
             )
             theglobalmaxlist.append(theglobalmax + 0)
             volumetotal += 1
-    print("\nCorrelation performed on " + str(volumetotal) + " voxels")
+    LGR.info(f"\nCorrelation performed on {volumetotal} voxels")
 
     # garbage collect
     collected = gc.collect()
-    print("Garbage collector: collected %d objects." % collected)
+    LGR.info(f"Garbage collector: collected {collected} objects.")
 
     return volumetotal, theglobalmaxlist, thecorrscale

--- a/rapidtide/calcsimfunc.py
+++ b/rapidtide/calcsimfunc.py
@@ -33,7 +33,7 @@ import rapidtide.resample as tide_resample
 import rapidtide.util as tide_util
 
 warnings.simplefilter(action="ignore", category=FutureWarning)
-LGR = logging.getLogger(__name__)
+LGR = logging.getLogger("GENERAL")
 
 
 def _procOneVoxelCorrelation(

--- a/rapidtide/correlate.py
+++ b/rapidtide/correlate.py
@@ -417,7 +417,6 @@ def cross_mutual_info(
     prebin=True,
     sigma=0.25,
     fast=True,
-    debug=False,
 ):
     """Calculate cross-mutual information between two 1D arrays.
     Parameters
@@ -447,8 +446,6 @@ def cross_mutual_info(
         histogram smoothing kernel
     fast: bool
         apply speed optimizations
-    debug : bool
-        set to True to output additional debugging information
 
     Returns
     -------
@@ -510,7 +507,6 @@ def cross_mutual_info(
                 normalized=norm,
                 fast=fast,
                 sigma=sigma,
-                debug=debug,
             )
         elif i == 0:
             thexmi_y[destloc] = mutual_info_2d(
@@ -520,7 +516,6 @@ def cross_mutual_info(
                 normalized=norm,
                 fast=fast,
                 sigma=sigma,
-                debug=debug,
             )
         else:
             thexmi_y[destloc] = mutual_info_2d(
@@ -530,7 +525,6 @@ def cross_mutual_info(
                 normalized=norm,
                 fast=fast,
                 sigma=sigma,
-                debug=debug,
             )
 
     if madnorm:

--- a/rapidtide/correlate.py
+++ b/rapidtide/correlate.py
@@ -20,7 +20,6 @@
 # $Id: tide_funcs.py,v 1.4 2016/07/12 13:50:29 frederic Exp $
 """Functions for calculating correlations and similar metrics between arrays."""
 import logging
-import sys
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -45,6 +44,7 @@ defaultbutterorder = 6
 MAXLINES = 10000000
 donotbeaggressive = True
 donotusenumba = True
+
 
 # ----------------------------------------- Conditional imports ---------------------------------------
 def conditionaljit():

--- a/rapidtide/correlate.py
+++ b/rapidtide/correlate.py
@@ -37,7 +37,7 @@ import rapidtide.resample as tide_resample
 import rapidtide.util as tide_util
 
 pyfftw.interfaces.cache.enable()
-LGR = logging.getLogger(__name__)
+LGR = logging.getLogger("GENERAL")
 
 # ---------------------------------------- Global constants -------------------------------------------
 defaultbutterorder = 6

--- a/rapidtide/correlate.py
+++ b/rapidtide/correlate.py
@@ -19,15 +19,17 @@
 # $Date: 2016/07/12 13:50:29 $
 # $Id: tide_funcs.py,v 1.4 2016/07/12 13:50:29 frederic Exp $
 """Functions for calculating correlations and similar metrics between arrays."""
+import logging
 import sys
 
 import matplotlib.pyplot as plt
 import numpy as np
 import pyfftw
+import pyfftw.interfaces.scipy_fftpack as fftpack
 import scipy as sp
 from numba import jit
 from numpy.fft import irfftn, rfftn
-from scipy import fftpack, signal
+from scipy import signal
 from sklearn.metrics import mutual_info_score
 
 import rapidtide.fit as tide_fit
@@ -35,8 +37,8 @@ import rapidtide.miscmath as tide_math
 import rapidtide.resample as tide_resample
 import rapidtide.util as tide_util
 
-fftpack = pyfftw.interfaces.scipy_fftpack
 pyfftw.interfaces.cache.enable()
+LGR = logging.getLogger(__name__)
 
 # ---------------------------------------- Global constants -------------------------------------------
 defaultbutterorder = 6
@@ -71,7 +73,6 @@ def check_autocorrelation(
     aclagthresh=10.0,
     displayplots=False,
     detrendorder=1,
-    debug=False,
 ):
     """Check for autocorrelation in an array.
 
@@ -85,7 +86,6 @@ def check_autocorrelation(
     displayplots
     windowfunc
     detrendorder
-    debug
 
     Returns
     -------
@@ -96,8 +96,7 @@ def check_autocorrelation(
     peaks = tide_fit.peakdetect(thexcorr, x_axis=corrscale, delta=delta, lookahead=lookahead)
     maxpeaks = np.asarray(peaks[0], dtype="float64")
     if len(peaks[0]) > 0:
-        if debug:
-            print(peaks)
+        LGR.debug(peaks)
         zeropkindex = np.argmin(abs(maxpeaks[:, 0]))
         for i in range(zeropkindex + 1, maxpeaks.shape[0]):
             if maxpeaks[i, 0] > aclagthresh:
@@ -206,7 +205,6 @@ def shorttermcorr_2D(
     windowfunc="None",
     detrendorder=0,
     display=False,
-    debug=False,
 ):
     """Calculate short-term sliding-window correlation between two 2D arrays.
 
@@ -222,7 +220,6 @@ def shorttermcorr_2D(
     windowfunc
     detrendorder
     display
-    debug
 
     Returns
     -------
@@ -242,8 +239,7 @@ def shorttermcorr_2D(
         lagmin = -windowtime / 2.0
         lagmax = windowtime / 2.0
 
-    if debug:
-        print("lag limits:", lagmin, lagmax)
+    LGR.debug(f"lag limits: {lagmin} {lagmax}")
 
     """dt = np.diff(time)[0]  # In days...
     fs = 1.0 / dt
@@ -331,9 +327,7 @@ def calc_MI(x, y, bins=50):
 
 
 @conditionaljit()
-def mutual_info_2d(
-    x, y, sigma=1, bins=(256, 256), fast=False, normalized=True, EPS=1.0e-6, debug=False
-):
+def mutual_info_2d(x, y, sigma=1, bins=(256, 256), fast=False, normalized=True, EPS=1.0e-6):
     """Compute (normalized) mutual information between two 1D variate from a joint histogram.
 
     Parameters
@@ -352,9 +346,6 @@ def mutual_info_2d(
         Default = False.
     EPS : float, optional
         Default = 1.0e-6.
-    debug : bool, optional
-        Whether to print extra information relevant for debugging or not.
-        Default = False.
 
     Returns
     -------
@@ -383,11 +374,8 @@ def mutual_info_2d(
         c += ((y[cuts] - ystart) / (yend - ystart) * numybins).astype(np.int_) * numxbins
         jh = np.bincount(c, minlength=numxbins * numybins).reshape(numxbins, numybins)
     else:
-        if debug:
-            jh, xbins, ybins = np.histogram2d(x, y, bins=bins)
-            print(xbins, ybins)
-        else:
-            jh = np.histogram2d(x, y, bins=bins)[0]
+        jh, xbins, ybins = np.histogram2d(x, y, bins=bins)
+        LGR.debug(f"{xbins} {ybins}")
 
     # smooth the jh with a gaussian filter of given sigma
     sp.ndimage.gaussian_filter(jh, sigma=sigma, mode="constant", output=jh)
@@ -407,8 +395,8 @@ def mutual_info_2d(
         mi = (HX + HY) / (HXcommaY) - 1.0
     else:
         mi = -(HXcommaY - HX - HY)
-    if debug:
-        print(HX, HY, HXcommaY, mi)
+
+    LGR.debug(f"{HX} {HY} {HXcommaY} {mi}")
 
     return mi
 
@@ -483,8 +471,7 @@ def cross_mutual_info(
     # see if we are using the default number of bins
     if bins < 1:
         bins = int(np.sqrt(len(x) / 5))
-        if debug:
-            print("cross_mutual_info: bins set to", bins)
+        LGR.debug(f"cross_mutual_info: bins set to {bins}")
 
     # find the bin locations
     if prebin:
@@ -504,8 +491,7 @@ def cross_mutual_info(
         possteps = possteps
     if locs is None:
         thexmi_y = np.zeros((-negsteps + possteps + 1))
-        if debug:
-            print("negsteps, possteps, len(thexmi_y)", negsteps, possteps, len(thexmi_y))
+        LGR.debug(f"negsteps, possteps, len(thexmi_y): {negsteps} {possteps} {len(thexmi_y)}")
         irange = range(negsteps, possteps + 1)
     else:
         thexmi_y = np.zeros((len(locs)), dtype=np.float64)
@@ -710,9 +696,9 @@ class AliasedCorrelator:
             offsetkey = "{:.3f}".format(theoffset)
             try:
                 aliasedhiressignal = self.aliasedsignals[offsetkey]
-                # print(offsetkey, ' - cache hit')
+                # LGR.info(f"{offsetkey} - cache hit")
             except KeyError:
-                # print(offsetkey, ' - cache miss')
+                # LGR.info(f"{offsetkey} - cache miss")
                 self.aliasedsignals[offsetkey] = tide_math.corrnormalize(
                     self.tcgenerator.yfromx(loresaxis + theoffset)
                 )
@@ -755,11 +741,10 @@ def arbcorr(
         - start2
     )
     zeroloc = int(np.argmin(np.fabs(thexcorr_x)))
-    if debug:
-        print("len(norm1) = ", len(norm1))
-        print("len(norm2) = ", len(norm2))
-        print("len(thexcorr_y)", len(thexcorr_y))
-        print("zeroloc =", zeroloc)
+    LGR.debug(f"len(norm1) = {len(norm1)}")
+    LGR.debug(f"len(norm2) = {len(norm2)}")
+    LGR.debug(f"len(thexcorr_y) = {len(thexcorr_y)}")
+    LGR.debug(f"zeroloc = {zeroloc}")
     return thexcorr_x, thexcorr_y, corrFs, zeroloc
 
 
@@ -1019,8 +1004,7 @@ def gccproduct(fft1, fft2, weighting, threshfrac=0.1, displayplots=False):
     elif weighting == "phat":
         denom = np.absolute(product)
     else:
-        print("illegal weighting function specified in gccproduct")
-        sys.exit()
+        raise ValueError("illegal weighting function specified in gccproduct")
 
     if displayplots:
         xvec = range(0, len(denom))

--- a/rapidtide/data/examples/src/testcrossMI
+++ b/rapidtide/data/examples/src/testcrossMI
@@ -45,7 +45,6 @@ for windowfunc in ["None"]:
                     returnaxis=True,
                     fast=False,
                     prebin=False,
-                    debug=False,
                 )
             endtime = time.perf_counter()
             print(
@@ -67,7 +66,6 @@ for windowfunc in ["None"]:
                     returnaxis=True,
                     fast=False,
                     prebin=True,
-                    debug=False,
                 )
             endtime = time.perf_counter()
             print(
@@ -89,7 +87,6 @@ for windowfunc in ["None"]:
                     returnaxis=True,
                     fast=True,
                     prebin=True,
-                    debug=False,
                 )
             endtime = time.perf_counter()
             print(

--- a/rapidtide/data/examples/src/testentropy
+++ b/rapidtide/data/examples/src/testentropy
@@ -62,7 +62,6 @@ for windowfunc in ["None"]:
                         returnaxis=True,
                         fast=True,
                         prebin=True,
-                        debug=True,
                     )
                     ax.plot(
                         thefastx,
@@ -93,7 +92,6 @@ for windowfunc in ["None"]:
                         returnaxis=True,
                         fast=True,
                         prebin=True,
-                        debug=True,
                     )
                     ax.plot(
                         thecorrx,

--- a/rapidtide/dlfilter.py
+++ b/rapidtide/dlfilter.py
@@ -36,7 +36,7 @@ pyfftw.interfaces.cache.enable()
 
 import rapidtide.io as tide_io
 
-LGR = logging.getLogger(__name__)
+LGR = logging.getLogger("GENERAL")
 LGR.debug("setting backend to Agg")
 mpl.use("Agg")
 

--- a/rapidtide/dlfilter.py
+++ b/rapidtide/dlfilter.py
@@ -1407,15 +1407,17 @@ def prep(
     # normalize input and output data
     LGR.info("normalizing data")
     LGR.info(f"count: {x.shape[1]}")
-    for thesubj in range(x.shape[1]):
-        LGR.debug(
-            f"prenorm sub {thesubj} min, max, mean, std, MAD x, y: "
-            f"{thesubj} "
-            f"{np.min(x[:, thesubj])} {np.max(x[:, thesubj])} {np.mean(x[:, thesubj])} "
-            f"{np.std(x[:, thesubj])} {mad(x[:, thesubj])} {np.min(y[:, thesubj])} "
-            f"{np.max(y[:, thesubj])} {np.mean(y[:, thesubj])} {np.std(x[:, thesubj])} "
-            f"{mad(y[:, thesubj])}"
-        )
+    if LGR.getEffectiveLevel() <= logging.DEBUG:
+        # Only take these steps if the logger is set to DEBUG.
+        for thesubj in range(x.shape[1]):
+            LGR.debug(
+                f"prenorm sub {thesubj} min, max, mean, std, MAD x, y: "
+                f"{thesubj} "
+                f"{np.min(x[:, thesubj])} {np.max(x[:, thesubj])} {np.mean(x[:, thesubj])} "
+                f"{np.std(x[:, thesubj])} {mad(x[:, thesubj])} {np.min(y[:, thesubj])} "
+                f"{np.max(y[:, thesubj])} {np.mean(y[:, thesubj])} {np.std(x[:, thesubj])} "
+                f"{mad(y[:, thesubj])}"
+            )
 
     y -= np.mean(y, axis=0)
     themad = mad(y, axis=0)
@@ -1429,15 +1431,17 @@ def prep(
         if themad[thesubj] > 0.0:
             x[:, thesubj] /= themad[thesubj]
 
-        for thesubj in range(x.shape[1]):
-            LGR.debug(
-                f"postnorm sub {thesubj} min, max, mean, std, MAD x, y: "
-                f"{thesubj} "
-                f"{np.min(x[:, thesubj])} {np.max(x[:, thesubj])} {np.mean(x[:, thesubj])} "
-                f"{np.std(x[:, thesubj])} {mad(x[:, thesubj])} {np.min(y[:, thesubj])} "
-                f"{np.max(y[:, thesubj])} {np.mean(y[:, thesubj])} {np.std(x[:, thesubj])} "
-                f"{mad(y[:, thesubj])}"
-            )
+        if LGR.getEffectiveLevel() <= logging.DEBUG:
+            # Only take these steps if the logger is set to DEBUG.
+            for thesubj in range(x.shape[1]):
+                LGR.debug(
+                    f"postnorm sub {thesubj} min, max, mean, std, MAD x, y: "
+                    f"{thesubj} "
+                    f"{np.min(x[:, thesubj])} {np.max(x[:, thesubj])} {np.mean(x[:, thesubj])} "
+                    f"{np.std(x[:, thesubj])} {mad(x[:, thesubj])} {np.min(y[:, thesubj])} "
+                    f"{np.max(y[:, thesubj])} {np.mean(y[:, thesubj])} {np.std(x[:, thesubj])} "
+                    f"{mad(y[:, thesubj])}"
+                )
 
     # now decide what to keep and what to exclude
     thefabs = np.fabs(x)

--- a/rapidtide/workflows/rapidtide.py
+++ b/rapidtide/workflows/rapidtide.py
@@ -2701,20 +2701,13 @@ def rapidtide_main(argparsingfunc):
         del fitcoeff
         del fitNorm
 
-    temp = {
-        "meanvalue": {
-            "data": meanvalue,
-            "suffix": "mean",
-        }
-    }
-    for mapname, temp_dict in temp.items():
-        outmaparray = temp_dict["data"]
-        mapsuffix = temp_dict["suffix"]
-
+    for mapname, mapsuffix in [("meanvalue", "mean")]:
         if optiondict["memprofile"]:
             memcheckpoint("about to write " + mapname)
         else:
             tide_util.logmem("about to write " + mapname)
+        outmaparray[:] = 0.0
+        outmaparray[:] = eval(mapname)[:]
 
         if optiondict["textio"]:
             tide_io.writenpvecs(

--- a/rapidtide/workflows/rapidtide.py
+++ b/rapidtide/workflows/rapidtide.py
@@ -67,7 +67,7 @@ try:
 except ImportError:
     memprofilerexists = False
 
-LGR = logging.getLogger(__name__)
+LGR = logging.getLogger("GENERAL")
 TimingLGR = logging.getLogger("TIMING")
 
 
@@ -711,7 +711,7 @@ def rapidtide_main(argparsingfunc):
 
         TimingLGR.info(
             "Motion filtering end",
-            {
+            extra={
                 "message2": fmri_data_valid.shape[0],
                 "message3": "voxels",
             },
@@ -2701,13 +2701,21 @@ def rapidtide_main(argparsingfunc):
         del fitcoeff
         del fitNorm
 
-    for mapname, mapsuffix in [("meanvalue", "mean")]:
+    temp = {
+        "meanvalue": {
+            "data": meanvalue,
+            "suffix": "mean",
+        }
+    }
+    for mapname, temp_dict in temp.items():
+        outmaparray = temp_dict["data"]
+        mapsuffix = temp_dict["suffix"]
+
         if optiondict["memprofile"]:
             memcheckpoint("about to write " + mapname)
         else:
             tide_util.logmem("about to write " + mapname)
-        outmaparray[:] = 0.0
-        outmaparray[:] = eval(mapname)[:]
+
         if optiondict["textio"]:
             tide_io.writenpvecs(
                 outmaparray.reshape(nativespaceshape),


### PR DESCRIPTION
<!---
This is a suggested pull request template for rapidtide.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
http://rapidtide.readthedocs.io/en/latest/contributing.html#pull-requests
-->

References #41.

Changes proposed in this pull request:

- Change how the general logger is initialized. I realized that the console messages were being weirdly duplicated because I was changing root settings for the general logger, which was only necessary when the general logger was initialized using each file's `__name__` (basically creating unique loggers, AFAIK). When you replace `__name__` with `"GENERAL"` (i.e., a shared logger, as with `"TIMING"` and `"MEMORY"`, you can change the settings for the general logger across all files.
    - The console outputs look WAY better and the log file is unaffected.
- Fix up the TimingLGR. It doesn't require `try`/`except` statements. I just had to fix up the `TimingFormatter`.
- Remove `debug` arguments for functions in `calcsimfunc.py`, `correlate.py`, and `dlfilter.py`. The goal is to replace `debug` with `LGR.debug` calls (hence no need for the argument).
    - Hopefully I removed `debug` from all calls to these altered functions, but I'm not 100% sure.
- Replace print statements with `LGR.info` calls. This also involves replacing comma-separated strings containing variables with f-strings.
    - E.g., `print("testing", var, "here")` --> `LGR.info(f"testing {var} here")`
