### PR TITLE
numpy.float deprecated, this is now changed in io.py

### DIFF
--- a/rapidtide/io.py
+++ b/rapidtide/io.py
@@ -1075,7 +1075,7 @@ def readcsv(inputfilename, debug=False):
 
     # Check to see if the first element is a float
     try:
-        dummy = np.float(df.columns[0])
+        dummy = float(df.columns[0])
 
         # if we got to here, reread the data, but assume there is no header line
         if debug:


### PR DESCRIPTION
When running rapidtide -CVR io.py was called and there was a line there that called np.float() which is deprecated in the latest numpy package (1.24.4). This was causing an error. Now fixed.

<!---
This is a suggested pull request template for rapidtide.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
http://rapidtide.readthedocs.io/en/latest/contributing.html#pull-requests
-->
[fix][ref]

Changes proposed in this pull request:

- np.float() changed to float in io.py in order to make it compatible with the latest numpy package