### PR TITLE
Update happy.py | mem check for singularity containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release history
 
-## Version 3.0alpha2 (12/20/24)
-* (package) Now includes codespell checking thank you to Yaroslav O. Halchenko (yarikoptic)!
+## Version 3.0alpha2 (12/30/24)
+* (happy, rapidtide) Now do more sophisticated container checkin to handle both Docker and Singularity. Thank you to Derek Monroe (https://github.com/dcmonroe) for the catch and the fix!
+* (package) Now includes codespell checking thanks to Yaroslav O. Halchenko (https://github.com/yarikoptic)!
 
 ## Version 3.0alpha1 (12/20/24)
 * (rapidtide) The ``--fixdelay`` option has been split into two options.  ``--initialdelay DELAY`` lets you specify either a float that sets the starting delay for every voxel to that value, or a 3D file specifying the initial delay for each voxel.  ``--nodelayfit`` determines whether the delay can be adjusted from its initial value.  Closes https://github.com/bbfrederick/rapidtide/issues/171. KNOWN ISSUE:  If you supply an initial delay map, instead of using the global mean, rapidtide should use the delays to make your first stage regressor.  Currently that is not the case.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release history
 
 ## Version 3.0alpha2 (12/30/24)
-* (happy, rapidtide) Now do more sophisticated container checkin to handle both Docker and Singularity. Thank you to Derek Monroe (https://github.com/dcmonroe) for the catch and the fix!
+* (happy, rapidtide) Now do more sophisticated container checking to handle both Docker and Singularity. Thank you to Derek Monroe (https://github.com/dcmonroe) for the catch and the fix!
 * (package) Now includes codespell checking thanks to Yaroslav O. Halchenko (https://github.com/yarikoptic)!
 
 ## Version 3.0alpha1 (12/20/24)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ authors = [
     {name = "Daniel M. Drucker, Ph.D."},
     {name = "Jeffrey N Stout"},
     {name = "Yaroslav O. Halchenko"},
+    {name = "Derek Monroe"},
 ]
 
 [project.urls]

--- a/rapidtide/util.py
+++ b/rapidtide/util.py
@@ -132,6 +132,30 @@ def findavailablemem():
         return free, swap
 
 
+def checkifincontainer():
+    # if running in Docker or Apptainer/Singularity, this is necessary to enforce mmemory limits properly
+    # otherwise likely to error out in gzip.py or at voxelnormalize step
+    try:
+        dummy = os.environ.get("RUNNING_IN_CONTAINER")
+    except KeyError:
+        try:
+            dummy = os.environ.get("SINGULARITY_CONTAINER")
+        except KeyError:
+            containertype = None
+        else:
+            containertype = "Singularity"
+    else:
+        containertype = "Docker"
+
+    try:
+        dummy = os.environ.get("CIRCLECI")
+    except KeyError:
+        pass
+    else:
+        containertype = "CircleCI"
+    return containertype
+
+
 def setmemlimit(memlimit):
     resource.setrlimit(resource.RLIMIT_AS, (memlimit, memlimit))
 

--- a/rapidtide/util.py
+++ b/rapidtide/util.py
@@ -139,10 +139,10 @@ def checkifincontainer():
     #
     # possible return values are: None, "Docker", "Singularity", and "CircleCI"
     #
-    if os.environ.get("RUNNING_IN_CONTAINER") is not None:
-        containertype = "Docker"
-    elif os.environ.get("SINGULARITY_CONTAINER") is not None:
+    if os.environ.get("SINGULARITY_CONTAINER") is not None:
         containertype = "Singularity"
+    elif os.environ.get("RUNNING_IN_CONTAINER") is not None:
+        containertype = "Docker"
     else:
         containertype = None
     if os.environ.get("CIRCLECI") is not None:

--- a/rapidtide/util.py
+++ b/rapidtide/util.py
@@ -139,25 +139,14 @@ def checkifincontainer():
     #
     # possible return values are: None, "Docker", "Singularity", and "CircleCI"
     #
-    try:
-        dummy = os.environ.get("RUNNING_IN_CONTAINER")
-    except KeyError:
-        try:
-            dummy = os.environ.get("SINGULARITY_CONTAINER")
-        except KeyError:
-            containertype = None
-        else:
-            containertype = "Singularity"
-    else:
+    if os.environ.get("RUNNING_IN_CONTAINER") is not None:
         containertype = "Docker"
-
-    if containertype is not None:
-        try:
-            dummy = os.environ.get("CIRCLECI")
-        except KeyError:
-            pass
-        else:
-            containertype = "CircleCI"
+    elif os.environ.get("SINGULARITY_CONTAINER") is not None:
+        containertype = "Singularity"
+    else:
+        containertype = None
+    if os.environ.get("CIRCLECI") is not None:
+        containertype = "CircleCI"
     return containertype
 
 

--- a/rapidtide/util.py
+++ b/rapidtide/util.py
@@ -151,12 +151,13 @@ def checkifincontainer():
     else:
         containertype = "Docker"
 
-    try:
-        dummy = os.environ.get("CIRCLECI")
-    except KeyError:
-        pass
-    else:
-        containertype = "CircleCI"
+    if containertype is not None:
+        try:
+            dummy = os.environ.get("CIRCLECI")
+        except KeyError:
+            pass
+        else:
+            containertype = "CircleCI"
     return containertype
 
 

--- a/rapidtide/util.py
+++ b/rapidtide/util.py
@@ -133,8 +133,12 @@ def findavailablemem():
 
 
 def checkifincontainer():
-    # if running in Docker or Apptainer/Singularity, this is necessary to enforce mmemory limits properly
-    # otherwise likely to error out in gzip.py or at voxelnormalize step
+    # Determine if the program is running in a container.  If so, we may need to adjust the python memory
+    # limits because they are not set properly.  But check if we're running on CircleCI - it does not seem
+    # to like you twiddling with the container parameters.
+    #
+    # possible return values are: None, "Docker", "Singularity", and "CircleCI"
+    #
     try:
         dummy = os.environ.get("RUNNING_IN_CONTAINER")
     except KeyError:

--- a/rapidtide/workflows/happy.py
+++ b/rapidtide/workflows/happy.py
@@ -77,28 +77,22 @@ def happy_main(argparsingfunc):
 
     # create the canary file
     Path(f"{outputroot}_ISRUNNING.txt").touch()
-
-    # if we are running in a container, make sure we enforce memory limits properly
+    
+    # if running in Docker or Apptainer/Singularity, this is necessary to enforce mmemory limits properly
+    # otherwise likely to  error out in gzip.py or at voxelnormalize step
     try:
-        testval = os.environ["RUNNING_IN_CONTAINER"]
+        container_env = os.environ["RUNNING_IN_CONTAINER"] or os.environ.get("SINGULARITY_NAME") or os.environ.get("SINGULARITY_CONTAINER")
     except KeyError:
         args.runningincontainer = False
     else:
         args.runningincontainer = True
         args.containermemfree, args.containermemswap = tide_util.findavailablemem()
-        tide_util.setmemlimit(args.containermemfree)
-    
-    # if running Apptainer/Singularity, this is necessary to enforce mmemory limits properly
-    # otherwise likely to  error out in gzip.py or at voxelnormalize step
-    try:
-        singularity_env = (os.environ.get("SINGULARITY_NAME") or os.environ.get("SINGULARITY_CONTAINER")) and not os.environ.get("CIRCLECI")
-    except KeyError:
-        args.runningincontainer = False
-    else:
-        args.runningincontainer = True
-        args.singularitymemfree, args.singularitymemswap = tide_util.findavailablemem()
-        tide_util.setmemlimit(args.singularitymemfree)
-
+        try:
+            cirlecienv = os.environ.get("CIRCLECI")
+        except KeyError:
+            tide_util.setmemlimit(args.containermemfree)
+        else:
+            print("running in CircleCI environment - not messing with memory")
 
     # Set up loggers for workflow
     setup_logger(

--- a/rapidtide/workflows/happy.py
+++ b/rapidtide/workflows/happy.py
@@ -91,7 +91,7 @@ def happy_main(argparsingfunc):
     # if running Apptainer/Singularity, this is necessary to enforce mmemory limits properly
     # otherwise likely to  error out in gzip.py or at voxelnormalize step
     try:
-        singularity_env = os.environ.get("SINGULARITY_NAME") or os.environ.get("SINGULARITY_CONTAINER")
+        singularity_env = (os.environ.get("SINGULARITY_NAME") or os.environ.get("SINGULARITY_CONTAINER")) and not os.environ.get("CIRCLECI")
     except KeyError:
         args.runningincontainer = False
     else:

--- a/rapidtide/workflows/happy.py
+++ b/rapidtide/workflows/happy.py
@@ -78,8 +78,9 @@ def happy_main(argparsingfunc):
     # create the canary file
     Path(f"{outputroot}_ISRUNNING.txt").touch()
 
-    # if running in Docker or Apptainer/Singularity, this is necessary to enforce mmemory limits properly
+    # if running in Docker or Apptainer/Singularity, this is necessary to enforce memory limits properly
     # otherwise likely to  error out in gzip.py or at voxelnormalize step.  But do nothing if running in CircleCI
+    # because it does NOT like you messing with the container.
     args.containertype = tide_util.checkifincontainer()
     if args.containertype is not None:
         if args.containertype != "CircleCI":

--- a/rapidtide/workflows/happy.py
+++ b/rapidtide/workflows/happy.py
@@ -87,6 +87,17 @@ def happy_main(argparsingfunc):
         args.runningindocker = True
         args.dockermemfree, args.dockermemswap = tide_util.findavailablemem()
         tide_util.setmemlimit(args.dockermemfree)
+    
+    # if running Apptainer/Singularity, this is necessary to enforce mmemory limits properly
+    # otherwise likely to  error out in gzip.py or at voxelnormalize step
+    try:
+        singularity_env = os.environ.get("SINGULARITY_NAME") or os.environ.get("SINGULARITY_CONTAINER")
+    except KeyError:
+        args.runninginsingularity = False
+    else:
+        args.runninginsingularity = True
+        args.singularitymemfree, args.singularitymemswap = tide_util.findavailablemem()
+        tide_util.setmemlimit(args.singularitymemfree)
 
     # Set up loggers for workflow
     setup_logger(

--- a/rapidtide/workflows/rapidtide.py
+++ b/rapidtide/workflows/rapidtide.py
@@ -269,8 +269,9 @@ def rapidtide_main(argparsingfunc):
         gc.enable()
         print("turning on garbage collection")
 
-    # if running in Docker or Apptainer/Singularity, this is necessary to enforce mmemory limits properly
+    # if running in Docker or Apptainer/Singularity, this is necessary to enforce memory limits properly
     # otherwise likely to  error out in gzip.py or at voxelnormalize step.  But do nothing if running in CircleCI
+    # because it does NOT like you messing with the container.
     optiondict["containertype"] = tide_util.checkifincontainer()
     if optiondict["containertype"] is not None:
         if optiondict["containertype"] != "CircleCI":

--- a/rapidtide/workflows/rapidtide.py
+++ b/rapidtide/workflows/rapidtide.py
@@ -269,14 +269,17 @@ def rapidtide_main(argparsingfunc):
         gc.enable()
         print("turning on garbage collection")
 
-    # if we are running in a container, make sure we enforce memory limits properly
-    if "RUNNING_IN_CONTAINER" in os.environ:
-        optiondict["runningincontainer"] = True
-        optiondict["containermemfree"], optiondict["containermemswap"] = tide_util.findavailablemem()
-        if optiondict["containermemfix"]:
+    # if running in Docker or Apptainer/Singularity, this is necessary to enforce mmemory limits properly
+    # otherwise likely to  error out in gzip.py or at voxelnormalize step.  But do nothing if running in CircleCI
+    optiondict["containertype"] = tide_util.checkifincontainer()
+    if optiondict["containertype"] is not None:
+        if optiondict["containertype"] != "CircleCI":
+            optiondict["containermemfree"], optiondict["containermemswap"] = (
+                tide_util.findavailablemem()
+            )
             tide_util.setmemlimit(optiondict["containermemfree"])
-    else:
-        optiondict["runningincontainer"] = False
+        else:
+            print("running in CircleCI environment - not messing with memory")
 
     # write out the current version of the run options
     optiondict["currentstage"] = "init"


### PR DESCRIPTION
Running happy in singularity on a Linux cluster caused crashes despite ample allocated memory/cores. 

I sandboxed the .simg and rebulit locally to confirm that this fix works.

Changes proposed in this pull request:

- check if rapidtide is running in a singularity container
- if so, run `tide_util.findavailablemem()`
