### PR TITLE
fix: Re-add versioneer hooks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+# Stub file to call setuptools.setup with versioneer hooks
+from setuptools import setup
+from versioneer import get_version, get_cmdclass
+
+setup(
+    version=get_version(),
+    cmdclass=get_cmdclass(),
+)


### PR DESCRIPTION
Versioneer does not magically inject setuptools hooks, so you need to use `get_cmdclass()` to ensure that the `_version.py` file is updated on installation.

I suspect we could simplify a lot of the versioning here by building the wheel within a Docker build layer, but it would be good to get an understanding of all the use cases you have for making the version available. We can then verify/add CI tests and comfortably start removing hacks.